### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.2.1...v0.2.2) - 2024-08-16
+
+### Added
+- added TryFrom<Vec<u8>> impl, changed current impl to not work on dmx packets, improved tests
+
 ## [0.2.1](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.2.0...v0.2.1) - 2024-08-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.2.1"
+version = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.65"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).