### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.2.2...v0.3.0) - 2024-08-16
+
+### Fixed
+- strings might not contain null characters, terminate early if they do
+
+### Other
+- removed imports and redundant error variant, added tests
+
 ## [0.2.2](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.2.1...v0.2.2) - 2024-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.2.2"
+version = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.65"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.2.2 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).