### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.3.1...v0.4.0) - 2024-09-28
+
+### Added
+
+- no_std support
+
+### Other
+
+- fix doc test bug
+- use interleaving cfg flag implementation for StatusMessage
+- rust fmt fixes
+- clearer no_std messaging in README
+- better doc examples
+
 ## [0.3.1](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.3.0...v0.3.1) - 2024-09-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "heapless",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `dmx512-rdm-protocol` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant DmxError:FailedToAllocate in /tmp/.tmpEzSYT4/dmx512-rdm-protocol/src/dmx/error.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).