### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.4.1...v0.5.0) - 2024-09-29
+
+### Added
+
+- added E1.37-1 parameters to request and response
+
+### Fixed
+
+- request parameter encoding issues
+
+### Other
+
+- added references to E1.37-1 spec
+- added PinCode struct, used in request and response
+- Added TimeMode enum and replaced current u16 impl
+- added SupportedTimes enum for preset info
+
 ## [0.4.1](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.4.0...v0.4.1) - 2024-09-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "heapless",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.4.1 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `dmx512-rdm-protocol` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant RequestParameter:GetDmxBlockAddress in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:215
  variant RequestParameter:SetDmxBlockAddress in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:216
  variant RequestParameter:GetDmxFailMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:219
  variant RequestParameter:SetDmxFailMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:220
  variant RequestParameter:GetDmxStartupMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:226
  variant RequestParameter:SetDmxStartupMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:227
  variant RequestParameter:GetDimmerInfo in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:233
  variant RequestParameter:GetMinimumLevel in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:234
  variant RequestParameter:SetMinimumLevel in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:235
  variant RequestParameter:GetMaximumLevel in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:240
  variant RequestParameter:SetMaximumLevel in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:241
  variant RequestParameter:GetCurve in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:244
  variant RequestParameter:SetCurve in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:245
  variant RequestParameter:GetCurveDescription in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:248
  variant RequestParameter:GetOutputResponseTime in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:251
  variant RequestParameter:SetOutputResponseTime in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:252
  variant RequestParameter:GetOutputResponseTimeDescription in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:255
  variant RequestParameter:GetModulationFrequency in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:258
  variant RequestParameter:SetModulationFrequency in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:259
  variant RequestParameter:GetModulationFrequencyDescription in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:262
  variant RequestParameter:GetPowerOnSelfTest in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:265
  variant RequestParameter:SetPowerOnSelfTest in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:266
  variant RequestParameter:GetLockState in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:269
  variant RequestParameter:SetLockState in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:270
  variant RequestParameter:GetLockStateDescription in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:274
  variant RequestParameter:GetLockPin in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:275
  variant RequestParameter:SetLockPin in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:276
  variant RequestParameter:GetBurnIn in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:280
  variant RequestParameter:SetBurnIn in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:281
  variant RequestParameter:GetIdentifyMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:284
  variant RequestParameter:SetIdentifyMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:285
  variant RequestParameter:GetPresetInfo in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:288
  variant RequestParameter:GetPresetStatus in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:289
  variant RequestParameter:GetPresetMergeMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:292
  variant RequestParameter:SetPresetMergeMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:293
  variant RequestParameter:SetPresetStatus in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/request.rs:296
  variant RdmError:InvalidIdentifyMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/error.rs:29
  variant RdmError:InvalidMergeMode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/error.rs:30
  variant RdmError:InvalidPresetProgrammed in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/error.rs:31
  variant RdmError:InvalidPinCode in /tmp/.tmpZUzhtE/dmx512-rdm-protocol/src/rdm/error.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).