### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.5.2...v0.6.0) - 2024-10-04
+
+### Added
+
+- added e1.37-2 spec parameters
+
+### Fixed
+
+- incorrect encoding of certain parameters
+- missing request parameter encoding
+
+### Other
+
+- fmt
+
 ## [0.5.2](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.5.1...v0.5.2) - 2024-10-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "heapless",
  "macaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.5.2 -> 0.6.0 (⚠️ API breaking changes)

### ⚠️ `dmx512-rdm-protocol` breaking changes

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum RdmError in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/error.rs:5

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant RequestParameter:GetListInterfaces in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:308
  variant RequestParameter:GetInterfaceLabel in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:309
  variant RequestParameter:GetInterfaceHardwareAddressType1 in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:312
  variant RequestParameter:GetIpV4DhcpMode in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:315
  variant RequestParameter:SetIpV4DhcpMode in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:318
  variant RequestParameter:GetIpV4ZeroConfMode in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:322
  variant RequestParameter:SetIpV4ZeroConfMode in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:325
  variant RequestParameter:GetIpV4CurrentAddress in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:329
  variant RequestParameter:GetIpV4StaticAddress in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:332
  variant RequestParameter:SetIpV4StaticAddress in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:335
  variant RequestParameter:SetInterfaceApplyConfiguration in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:340
  variant RequestParameter:SetInterfaceRenewDhcp in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:343
  variant RequestParameter:SetInterfaceReleaseDhcp in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:346
  variant RequestParameter:GetIpV4DefaultRoute in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:349
  variant RequestParameter:SetIpV4DefaultRoute in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:350
  variant RequestParameter:GetDnsIpV4NameServer in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:354
  variant RequestParameter:SetDnsIpV4NameServer in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:357
  variant RequestParameter:GetDnsHostName in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:361
  variant RequestParameter:SetDnsHostName in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:362
  variant RequestParameter:GetDnsDomainName in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:368
  variant RequestParameter:SetDnsDomainName in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/request.rs:369
  variant ResponseNackReasonCode:ActionNotSupported in /tmp/.tmpqt0xkM/dmx512-rdm-protocol/src/rdm/response.rs:82
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).