### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.6.0...v0.7.0) - 2024-10-04
+
+### Added
+
+- added e1.33 spec parameters
+
+### Other
+
+- reworded implemented / supported parameters
+- added E1.33 references to README
+- use extend with turbofish rather than intermediate uint conversion
+
 ## [0.6.0](https://github.com/mpowell90/dmx512-rdm-protocol/compare/v0.5.2...v0.6.0) - 2024-10-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "heapless",
  "macaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.6.0 -> 0.7.0 (⚠️ API breaking changes)

### ⚠️ `dmx512-rdm-protocol` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant RequestParameter:GetSearchDomain in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:376
  variant RequestParameter:SetSearchDomain in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:377
  variant RequestParameter:GetComponentScope in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:381
  variant RequestParameter:SetComponentScope in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:384
  variant RequestParameter:GetTcpCommsStatus in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:395
  variant RequestParameter:SetTcpCommsStatus in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:396
  variant RequestParameter:GetBrokerStatus in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:402
  variant RequestParameter:SetBrokerStatus in /tmp/.tmp0CCc8w/dmx512-rdm-protocol/src/rdm/request.rs:403
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).