### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "heapless",
  "macaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.7.4 -> 0.8.0 (⚠️ API breaking changes)

### ⚠️ `dmx512-rdm-protocol` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant ResponseNackReasonCode:EndpointNumberInvalid in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/response.rs:83
  variant ResponseNackReasonCode:InvalidEndpointMode in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/response.rs:84
  variant ResponseNackReasonCode:UnknownUid in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/response.rs:85
  variant RequestParameter:GetEndpointList in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:377
  variant RequestParameter:GetEndpointListChange in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:378
  variant RequestParameter:GetIdentifyEndpoint in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:379
  variant RequestParameter:SetIdentifyEndpoint in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:382
  variant RequestParameter:GetEndpointToUniverse in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:386
  variant RequestParameter:SetEndpointToUniverse in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:389
  variant RequestParameter:GetEndpointMode in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:393
  variant RequestParameter:SetEndpointMode in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:396
  variant RequestParameter:GetEndpointLabel in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:400
  variant RequestParameter:SetEndpointLabel in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:403
  variant RequestParameter:GetRdmTrafficEnable in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:410
  variant RequestParameter:SetRdmTrafficEnable in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:413
  variant RequestParameter:GetDiscoveryState in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:417
  variant RequestParameter:SetDiscoveryState in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:420
  variant RequestParameter:GetBackgroundDiscovery in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:424
  variant RequestParameter:SetBackgroundDiscovery in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:427
  variant RequestParameter:GetEndpointTiming in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:431
  variant RequestParameter:SetEndpointTiming in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:434
  variant RequestParameter:GetEndpointTimingDescription in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:438
  variant RequestParameter:GetEndpointResponders in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:441
  variant RequestParameter:GetEndpointResponderListChange in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:444
  variant RequestParameter:GetBindingControlFields in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:447
  variant RequestParameter:GetBackgroundQueuedStatusPolicy in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:451
  variant RequestParameter:SetBackgroundQueuedStatusPolicy in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:452
  variant RequestParameter:GetBackgroundQueuedStatusPolicyDescription in /tmp/.tmpMnnaBi/dmx512-rdm-protocol/src/rdm/request.rs:455
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).