### PR TITLE
fix(cargo): gate macaddr/std feature with alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["dmx", "rdm", "lighting", "protocol", "control"]
 [features]
 default = ["rdm", "alloc"]
 rdm = []
-alloc = []
+alloc = ["macaddr/std"]
 
 [dependencies]
 heapless = "0.8.0"
-macaddr = "1.0.1"
+macaddr = { version = "1.0.1", default-features = false }


### PR DESCRIPTION
This fixes currently broken no_std build, because `macaddr` is by default std.

Please consider merging.

Make a new release then if possible :-)

Thanks.