### PR TITLE
fix(response): check actual length against protocol field

### DIFF
--- a/src/rdm/response.rs
+++ b/src/rdm/response.rs
@@ -3011,6 +3011,10 @@ impl RdmFrameResponse {
             return Err(RdmError::InvalidMessageLength(message_length));
         }
 
+        if bytes.len() < message_length as usize + 2 {
+            return Err(RdmError::InvalidMessageLength(message_length));
+        }
+
         let packet_checksum = u16::from_be_bytes(
             bytes[message_length as usize..=message_length as usize + 1].try_into()?,
         );


### PR DESCRIPTION
If frame is incomplete or damaged, unchecked access to checksum presumably stored in bytes array can cause panic.

Caught this during controller development.