### PR TITLE
Update for E1.37-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Remote Device Management (RDM) is a backward-compatible extension of DMX512, ena
 - ANSI E1.20 (2010): RDM Remote Device Management Over DMX512 Networks [Implemented]
 - ANSI E1.37-1 (2012): Additional Message Sets for ANSI E1.20 (RDM) – Part 1, Dimmer Message Sets [Implemented]
 - ANSI E1.37-2 (2015): Additional Message Sets for ANSI E1.20 (RDM) – Part 2, IPv4 & DNS Configuration Messages [Implemented]
+- ANSI E1.37-5 (2024): General Purpose Messages for E1.20 RDM [Implemented]
 - ANSI E1.37-7 (2019): Additional Message Sets for ANSI E1.20 (RDM) – Gateway & Splitter Configuration Messages [Implemented]
 - ANSI E1.33 (RDMnet): Message Transport and Management for ANSI E1.20 (RDM) compatible and similar devices over IP Networks [Supported]
 
@@ -177,6 +178,6 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 
 ## Acknowledgments
 
-- The ANSI E1.11 (2008), ANSI E1.20 (2010), ANSI E1.37-1 (2012), ANSI E1.37-2 (2015), ANSI E1.37-7 (2019) and ANSI E1.33 (RDMnet) specifications used to create this library is copyright and published by [ESTA](https://www.esta.org/)
+- The ANSI E1.11 (2008), ANSI E1.20 (2010), ANSI E1.37-1 (2012), ANSI E1.37-2 (2015), ANSI E1.37-5 (2024), ANSI E1.37-7 (2019) and ANSI E1.33 (RDMnet) specifications used to create this library is copyright and published by [ESTA](https://www.esta.org/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/src/rdm/error.rs
+++ b/src/rdm/error.rs
@@ -37,6 +37,7 @@ pub enum RdmError {
     InvalidDiscoveryState(u8),
     InvalidEndpointMode(u8),
     InvalidEndpointType(u8),
+    InvalidShippingLockState(u8),
     MalformedPacket,
 }
 
@@ -137,6 +138,9 @@ impl fmt::Display for RdmError {
             Self::InvalidDiscoveryState(discovery_state) => write!(f, "Invalid DiscoveryState: {}", discovery_state),
             Self::InvalidEndpointMode(endpoint_mode) => write!(f, "Invalid EndpointMode: {}", endpoint_mode),
             Self::InvalidEndpointType(endpoint_type) => write!(f, "Invalid EndpointType: {}", endpoint_type),
+            Self::InvalidShippingLockState(shipping_lock_state) => {
+                write!(f, "Invalid ShippingLockState: {}", shipping_lock_state)
+            }
             Self::MalformedPacket => write!(f, "Malformed packet"),
         }
     }

--- a/src/rdm/parameter.rs
+++ b/src/rdm/parameter.rs
@@ -125,6 +125,29 @@ pub enum ParameterId {
     DnsIpV4NameServer,
     DnsHostName,
     DnsDomainName,
+    // E1.37-5 2024 Table A-1
+    ManufacturerUrl,
+    ProductUrl,
+    FirmwareUrl,
+    SerialNumber,
+    DeviceInfoOffstage,
+    TestData,
+    CommsStatusNsc,
+    IdentifyTimeout,
+    PowerOffReady,
+    ShippingLock,
+    ListTags,
+    AddTag,
+    RemoveTag,
+    CheckTag,
+    ClearTags,
+    DeviceUnitNumber,
+    DmxPersonalityId,
+    SensorTypeCustom,
+    SensorUnitCustom,
+    MetadataParameterVersion,
+    MetadataJson,
+    MetadataJsonUrl,
     // E1.37-7 2019 Table A-1
     EndpointList,
     EndpointListChange,
@@ -244,6 +267,29 @@ impl From<u16> for ParameterId {
             0x070b => Self::DnsIpV4NameServer,
             0x070c => Self::DnsHostName,
             0x070d => Self::DnsDomainName,
+            // E1.37-5
+            0x00d0 => Self::ManufacturerUrl,
+            0x00d1 => Self::ProductUrl,
+            0x00d2 => Self::FirmwareUrl,
+            0x00d3 => Self::SerialNumber,
+            0x00d4 => Self::DeviceInfoOffstage,
+            0x0016 => Self::TestData,
+            0x0017 => Self::CommsStatusNsc,
+            0x1050 => Self::IdentifyTimeout,
+            0x1051 => Self::PowerOffReady,
+            0x0650 => Self::ShippingLock,
+            0x0651 => Self::ListTags,
+            0x0652 => Self::AddTag,
+            0x0653 => Self::RemoveTag,
+            0x0654 => Self::CheckTag,
+            0x0655 => Self::ClearTags,
+            0x0656 => Self::DeviceUnitNumber,
+            0x00e2 => Self::DmxPersonalityId,
+            0x0210 => Self::SensorTypeCustom,
+            0x0211 => Self::SensorUnitCustom,
+            0x0052 => Self::MetadataParameterVersion,
+            0x0053 => Self::MetadataJson,
+            0x0054 => Self::MetadataJsonUrl,
             // E1.37-7
             0x0900 => Self::EndpointList,
             0x0901 => Self::EndpointListChange,
@@ -365,6 +411,29 @@ impl From<ParameterId> for u16 {
             ParameterId::DnsIpV4NameServer => 0x070b,
             ParameterId::DnsHostName => 0x070c,
             ParameterId::DnsDomainName => 0x070d,
+            // E1.37-5
+            ParameterId::ManufacturerUrl => 0x00d0,
+            ParameterId::ProductUrl => 0x00d1,
+            ParameterId::FirmwareUrl => 0x00d2,
+            ParameterId::SerialNumber => 0x00d3,
+            ParameterId::DeviceInfoOffstage => 0x00d4,
+            ParameterId::TestData => 0x0016,
+            ParameterId::CommsStatusNsc => 0x0017,
+            ParameterId::IdentifyTimeout => 0x1050,
+            ParameterId::PowerOffReady => 0x1051,
+            ParameterId::ShippingLock => 0x0650,
+            ParameterId::ListTags => 0x0651,
+            ParameterId::AddTag => 0x0652,
+            ParameterId::RemoveTag => 0x0653,
+            ParameterId::CheckTag => 0x0654,
+            ParameterId::ClearTags => 0x0655,
+            ParameterId::DeviceUnitNumber => 0x0656,
+            ParameterId::DmxPersonalityId => 0x00e2,
+            ParameterId::SensorTypeCustom => 0x0210,
+            ParameterId::SensorUnitCustom => 0x0211,
+            ParameterId::MetadataParameterVersion => 0x0052,
+            ParameterId::MetadataJson => 0x0053,
+            ParameterId::MetadataJsonUrl => 0x0054,
             // E1.37-7
             ParameterId::EndpointList => 0x0900,
             ParameterId::EndpointListChange => 0x0901,
@@ -700,6 +769,66 @@ impl TryFrom<u8> for ImplementedCommandClass {
             0x03 => Ok(Self::GetSet),
             _ => Err(RdmError::InvalidCommandClassImplementation(value)),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DeviceInfo {
+    pub protocol_version: ProtocolVersion,
+    pub model_id: u16,
+    pub product_category: ProductCategory,
+    pub software_version_id: u32,
+    pub footprint: u16,
+    pub current_personality: u8,
+    pub personality_count: u8,
+    pub start_address: u16,
+    pub sub_device_count: u16,
+    pub sensor_count: u8,
+}
+impl DeviceInfo {
+    #[cfg(feature = "alloc")]
+    pub fn encode(&self, buf: &mut Vec<u8>) {
+        buf.reserve(19);
+        buf.extend(u16::from(self.protocol_version).to_be_bytes());
+        buf.extend(self.model_id.to_be_bytes());
+        buf.extend(u16::from(self.product_category).to_be_bytes());
+        buf.extend(self.software_version_id.to_be_bytes());
+        buf.extend(self.footprint.to_be_bytes());
+        buf.push(self.current_personality);
+        buf.push(self.personality_count);
+        buf.extend(self.start_address.to_be_bytes());
+        buf.extend(self.sub_device_count.to_be_bytes());
+        buf.push(self.sensor_count);
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    pub fn encode(&self, buf: &mut Vec<u8, 231>) {    
+        buf.extend(u16::from(self.protocol_version).to_be_bytes());
+        buf.extend(self.model_id.to_be_bytes());
+        buf.extend(u16::from(self.product_category).to_be_bytes());
+        buf.extend(self.software_version_id.to_be_bytes());
+        buf.extend(self.footprint.to_be_bytes());
+        buf.push(self.current_personality).unwrap();
+        buf.push(self.personality_count).unwrap();
+        buf.extend(self.start_address.to_be_bytes());
+        buf.extend(self.sub_device_count.to_be_bytes());
+        buf.push(self.sensor_count).unwrap();
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, RdmError> {
+        check_msg_len!(bytes, 19);
+        Ok(Self {
+            protocol_version: ProtocolVersion::new(bytes[0], bytes[1]),
+            model_id: u16::from_be_bytes(bytes[2..=3].try_into()?),
+            product_category: u16::from_be_bytes(bytes[4..=5].try_into()?).into(),
+            software_version_id: u32::from_be_bytes(bytes[6..=9].try_into()?),
+            footprint: u16::from_be_bytes(bytes[10..=11].try_into()?),
+            current_personality: bytes[12],
+            personality_count: bytes[13],
+            start_address: u16::from_be_bytes(bytes[14..=15].try_into()?),
+            sub_device_count: u16::from_be_bytes(bytes[16..=17].try_into()?),
+            sensor_count: u8::from_be(bytes[18]),
+        })
     }
 }
 
@@ -2836,6 +2965,27 @@ impl From<IdentifyTimeout> for u16 {
         match value {
             IdentifyTimeout::Disabled => 0,
             IdentifyTimeout::Seconds(s) => s,
+        }
+    }
+}
+
+// E1.37-5 2024 Table A-2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShippingLockState {
+    Unlocked = 0x00,
+    Locked = 0x01,
+    PartiallyLocked = 0x02,
+}
+
+impl TryFrom<u8> for ShippingLockState {
+    type Error = RdmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Unlocked),
+            0x01 => Ok(Self::Locked),
+            0x02 => Ok(Self::PartiallyLocked),
+            _ => Err(RdmError::InvalidShippingLockState(value))
         }
     }
 }

--- a/src/rdm/request.rs
+++ b/src/rdm/request.rs
@@ -43,8 +43,8 @@ use super::{
     bsd_16_crc,
     error::RdmError,
     parameter::{
-        decode_string_bytes, BrokerState, DiscoveryState, DisplayInvertMode, EndpointId,
-        EndpointMode, FadeTimes, IdentifyMode, Ipv4Address, Ipv4Route, Ipv6Address, LampOnMode, LampState,
+        decode_string_bytes, BrokerState, DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode,
+        FadeTimes, IdentifyMode, IdentifyTimeout, Ipv4Address, Ipv4Route, Ipv6Address, LampOnMode, LampState,
         MergeMode, ParameterId, PinCode, PowerState, PresetPlaybackMode, ResetDeviceMode, SelfTest,
         StaticConfigType, StatusType, TimeMode,
     },
@@ -377,6 +377,76 @@ pub enum RequestParameter {
         #[cfg(not(feature = "alloc"))]
         domain_name: String<231>,
     },
+    // E1.37-5
+    GetIdentifyTimeout,
+    SetIdentifyTimeout {
+        timeout: IdentifyTimeout
+    },
+    GetManufacturerUrl,
+    GetProductUrl,
+    GetFirmwareUrl,
+    GetShippingLock,
+    SetShippingLock {
+        locked: bool
+    },
+    GetPowerOffReady,
+    GetSerialNumber,
+    GetTestData {
+        pattern_length: u16,
+    },
+    SetTestData {
+        #[cfg(feature = "alloc")]
+        loopback_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))]
+        loopback_data: Vec<u8, 231>,
+    },
+    GetCommsStatusNsc,
+    SetCommsStatusNsc,
+    GetResponderTags,
+    SetAddTag {
+        #[cfg(feature = "alloc")]
+        tag: String,
+        #[cfg(not(feature = "alloc"))]
+        tag: String<32>,
+    },
+    SetRemoveTag {
+        #[cfg(feature = "alloc")]
+        tag: String,
+        #[cfg(not(feature = "alloc"))]
+        tag: String<32>,
+    },
+    GetCheckTag {
+        #[cfg(feature = "alloc")]
+        tag: String,
+        #[cfg(not(feature = "alloc"))]
+        tag: String<32>,
+    },
+    SetClearTags,
+    GetDeviceUnitNumber,
+    SetDeviceUnitNumber {
+        unit_number: u32,
+    },
+    GetDmxPersonalityId {
+        personality_number: u8,
+    },
+    GetDeviceInfoOffstage {
+        root_personality: u8,
+        sub_device: SubDeviceId,
+        sub_device_personality: u8,
+    },
+    GetSensorTypeCustom {
+        sensor_type: u8,
+    },
+    GetSensorUnitCustom {
+        sensor_unit: u8,
+    },
+    GetMetadataParameterVersion {
+        parameter_id: ParameterId,
+    },
+    GetMetadataJson {
+        parameter_id: ParameterId,
+    },
+    GetMetadataJsonUrl,
     // E1.37-7
     GetEndpointList,
     GetEndpointListChange,
@@ -594,6 +664,26 @@ impl RequestParameter {
             | Self::GetDnsIpV4NameServer { .. }
             | Self::GetDnsHostName
             | Self::GetDnsDomainName
+            // E1.37-5
+            | Self::GetIdentifyTimeout
+            | Self::GetManufacturerUrl
+            | Self::GetProductUrl
+            | Self::GetFirmwareUrl
+            | Self::GetShippingLock
+            | Self::GetPowerOffReady
+            | Self::GetSerialNumber
+            | Self::GetTestData { .. }
+            | Self::GetCommsStatusNsc
+            | Self::GetResponderTags
+            | Self::GetCheckTag { .. }
+            | Self::GetDeviceUnitNumber
+            | Self::GetDmxPersonalityId { .. }
+            | Self::GetDeviceInfoOffstage { .. }
+            | Self::GetSensorTypeCustom { .. }
+            | Self::GetSensorUnitCustom { .. }
+            | Self::GetMetadataParameterVersion { .. }
+            | Self::GetMetadataJson { .. }
+            | Self::GetMetadataJsonUrl
             // E1.37-7
             | Self::GetEndpointList
             | Self::GetEndpointListChange
@@ -673,6 +763,15 @@ impl RequestParameter {
             | Self::SetDnsIpV4NameServer { .. }
             | Self::SetDnsHostName { .. }
             | Self::SetDnsDomainName { .. }
+            // E1.37-5
+            | Self::SetIdentifyTimeout { .. }
+            | Self::SetShippingLock { .. }
+            | Self::SetTestData { .. }
+            | Self::SetCommsStatusNsc
+            | Self::SetAddTag { .. }
+            | Self::SetRemoveTag { .. }
+            | Self::SetClearTags
+            | Self::SetDeviceUnitNumber { .. }
             // E1.37-7
             | Self::SetIdentifyEndpoint { .. }
             | Self::SetEndpointToUniverse { .. }
@@ -823,6 +922,29 @@ impl RequestParameter {
             }
             Self::GetDnsHostName | Self::SetDnsHostName { .. } => ParameterId::DnsHostName,
             Self::GetDnsDomainName | Self::SetDnsDomainName { .. } => ParameterId::DnsDomainName,
+            // E1.37-5
+            Self::GetIdentifyTimeout | Self::SetIdentifyTimeout { .. } => ParameterId::IdentifyTimeout,
+            Self::GetManufacturerUrl => ParameterId::ManufacturerUrl,
+            Self::GetProductUrl => ParameterId::ProductUrl,
+            Self::GetFirmwareUrl => ParameterId::FirmwareUrl,
+            Self::GetShippingLock | Self::SetShippingLock { .. } => ParameterId::ShippingLock,
+            Self::GetPowerOffReady => ParameterId::PowerOffReady,
+            Self::GetSerialNumber => ParameterId::SerialNumber,
+            Self::GetTestData { .. } | Self::SetTestData { .. } => ParameterId::TestData,
+            Self::GetCommsStatusNsc | Self::SetCommsStatusNsc => ParameterId::CommsStatusNsc,
+            Self::GetResponderTags => ParameterId::ListTags,
+            Self::SetAddTag { .. } => ParameterId::AddTag,
+            Self::SetRemoveTag { .. } => ParameterId::RemoveTag,
+            Self::GetCheckTag { .. } => ParameterId::CheckTag,
+            Self::SetClearTags => ParameterId::ClearTags,
+            Self::GetDeviceUnitNumber | Self::SetDeviceUnitNumber { .. } => ParameterId::DeviceUnitNumber,
+            Self::GetDmxPersonalityId { .. } => ParameterId::DmxPersonalityId,
+            Self::GetDeviceInfoOffstage { .. } => ParameterId::DeviceInfoOffstage,
+            Self::GetSensorTypeCustom { .. } => ParameterId::SensorTypeCustom,
+            Self::GetSensorUnitCustom { .. } => ParameterId::SensorUnitCustom,
+            Self::GetMetadataParameterVersion { .. } => ParameterId::MetadataParameterVersion,
+            Self::GetMetadataJson { .. } => ParameterId::MetadataJson,
+            Self::GetMetadataJsonUrl => ParameterId::MetadataJsonUrl,
             // E1.37-7
             Self::GetEndpointList => ParameterId::EndpointList,
             Self::GetEndpointListChange => ParameterId::EndpointListChange,
@@ -1634,6 +1756,114 @@ impl RequestParameter {
 
                 buf.extend(domain_name.bytes())
             }
+            // E1.37-5
+            Self::GetIdentifyTimeout => {}
+            Self::SetIdentifyTimeout { timeout } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x02);
+
+                buf.extend(u16::from(*timeout).to_be_bytes());
+            }
+            Self::GetManufacturerUrl => {}
+            Self::GetProductUrl => {}
+            Self::GetFirmwareUrl => {}
+            Self::GetShippingLock => {}
+            Self::SetShippingLock { locked } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x01);
+
+                #[cfg(feature = "alloc")]
+                buf.push(if *locked {1} else {0});
+                #[cfg(not(feature = "alloc"))]
+                buf.push(if *locked {1} else {0}).unwrap();
+            }
+            Self::GetPowerOffReady => {}
+            Self::GetSerialNumber => {}
+            Self::GetTestData { pattern_length } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x02);
+
+                buf.extend((*pattern_length).to_be_bytes());
+            }
+            Self::SetTestData { loopback_data } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(loopback_data.len());
+
+                #[cfg(feature = "alloc")]
+                buf.extend(loopback_data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(loopback_data).unwrap();
+            }
+            Self::GetCommsStatusNsc => {}
+            Self::SetCommsStatusNsc => {}
+            Self::GetResponderTags => {}
+            Self::SetAddTag { tag } |
+            Self::SetRemoveTag { tag } |
+            Self::GetCheckTag { tag } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(tag.len());
+
+                buf.extend(tag.bytes())
+            }
+            Self::SetClearTags => {}
+            Self::GetDeviceUnitNumber => {}
+            Self::SetDeviceUnitNumber { unit_number } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4);
+
+                buf.extend((*unit_number).to_be_bytes());
+            }
+            Self::GetDmxPersonalityId { personality_number } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*personality_number);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*personality_number).unwrap();
+            }
+            Self::GetDeviceInfoOffstage { root_personality, sub_device, sub_device_personality } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*root_personality);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*root_personality).unwrap();
+                
+                buf.extend(u16::from(*sub_device).to_be_bytes());
+
+                #[cfg(feature = "alloc")]
+                buf.push(*sub_device_personality);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*sub_device_personality).unwrap();
+            }
+            Self::GetSensorTypeCustom { sensor_type } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*sensor_type);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*sensor_type).unwrap();
+            }
+            Self::GetSensorUnitCustom { sensor_unit } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*sensor_unit);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*sensor_unit).unwrap();
+            }
+            Self::GetMetadataParameterVersion { parameter_id } |
+            Self::GetMetadataJson { parameter_id } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(2);
+
+                buf.extend(u16::from(*parameter_id).to_be_bytes());
+            }
+            Self::GetMetadataJsonUrl => {}
             // E1.37-7
             Self::GetEndpointList => {}
             Self::GetEndpointListChange => {}
@@ -2485,6 +2715,104 @@ impl RequestParameter {
             (CommandClass::SetCommand, ParameterId::DnsDomainName) => Ok(Self::SetDnsDomainName {
                 domain_name: decode_string_bytes(bytes)?,
             }),
+            // E1.37-5
+            (CommandClass::GetCommand, ParameterId::IdentifyTimeout) => Ok(Self::GetIdentifyTimeout),
+            (CommandClass::SetCommand, ParameterId::IdentifyTimeout) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::SetIdentifyTimeout {
+                    timeout: u16::from_be_bytes([bytes[0], bytes[1]]).into()
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::ManufacturerUrl) => Ok(Self::GetManufacturerUrl),
+            (CommandClass::GetCommand, ParameterId::ProductUrl) => Ok(Self::GetProductUrl),
+            (CommandClass::GetCommand, ParameterId::FirmwareUrl) => Ok(Self::GetFirmwareUrl),
+            (CommandClass::GetCommand, ParameterId::ShippingLock) => Ok(Self::GetShippingLock),
+            (CommandClass::SetCommand, ParameterId::ShippingLock) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::SetShippingLock {
+                    locked: bytes[0] != 0
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::PowerOffReady) => Ok(Self::GetPowerOffReady),
+            (CommandClass::GetCommand, ParameterId::SerialNumber) => Ok(Self::GetSerialNumber),
+            (CommandClass::GetCommand, ParameterId::TestData) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetTestData {
+                    pattern_length: u16::from_be_bytes([bytes[0], bytes[1]]).into()
+                })
+            }
+            (CommandClass::SetCommand, ParameterId::TestData) => {
+                #[cfg(feature = "alloc")]
+                let loopback_data = bytes[..bytes.len().min(231)].into();
+                #[cfg(not(feature = "alloc"))]
+                let loopback_data = Vec::<u8, 231>::from_slice(&bytes[..bytes.len().min(231)]).unwrap();
+                Ok(Self::SetTestData{ loopback_data })
+            }
+            (CommandClass::GetCommand, ParameterId::CommsStatusNsc) => Ok(Self::GetCommsStatusNsc),
+            (CommandClass::SetCommand, ParameterId::CommsStatusNsc) => Ok(Self::SetCommsStatusNsc),
+            (CommandClass::GetCommand, ParameterId::ListTags) => Ok(Self::GetResponderTags),
+            (CommandClass::SetCommand, ParameterId::AddTag) => {
+                Ok(Self::SetAddTag {
+                    tag: decode_string_bytes(&bytes[..bytes.len().min(32)])?,
+                })
+            }
+            (CommandClass::SetCommand, ParameterId::RemoveTag) => {
+                Ok(Self::SetRemoveTag {
+                    tag: decode_string_bytes(&bytes[..bytes.len().min(32)])?,
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::CheckTag) => {
+                Ok(Self::GetCheckTag {
+                    tag: decode_string_bytes(&bytes[..bytes.len().min(32)])?,
+                })
+            }
+            (CommandClass::SetCommand, ParameterId::ClearTags) => Ok(Self::SetClearTags),
+            (CommandClass::GetCommand, ParameterId::DeviceUnitNumber) => Ok(Self::GetDeviceUnitNumber),
+            (CommandClass::SetCommand, ParameterId::DeviceUnitNumber) => {
+                check_msg_len!(bytes, 4);
+                Ok(Self::SetDeviceUnitNumber {
+                    unit_number: u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::DmxPersonalityId) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetDmxPersonalityId {
+                    personality_number: bytes[0]
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::DeviceInfoOffstage) => {
+                check_msg_len!(bytes, 4);
+                Ok(Self::GetDeviceInfoOffstage {
+                    root_personality: bytes[0],
+                    sub_device: u16::from_be_bytes([bytes[1], bytes[2]]).into(),
+                    sub_device_personality: bytes[3]
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::SensorTypeCustom) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetSensorTypeCustom {
+                    sensor_type: bytes[0]
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::SensorUnitCustom) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetSensorUnitCustom {
+                    sensor_unit: bytes[0]
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::MetadataParameterVersion) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetMetadataParameterVersion {
+                    parameter_id: u16::from_be_bytes([bytes[0], bytes[1]]).into()
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::MetadataJson) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetMetadataJson {
+                    parameter_id: u16::from_be_bytes([bytes[0], bytes[1]]).into()
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::MetadataJsonUrl) => Ok(Self::GetMetadataJsonUrl),
             // E1.37-7
             (CommandClass::GetCommand, ParameterId::EndpointList) => Ok(Self::GetEndpointList),
             (CommandClass::GetCommand, ParameterId::EndpointListChange) => {

--- a/src/rdm/response.rs
+++ b/src/rdm/response.rs
@@ -48,12 +48,12 @@
 use super::{
     bsd_16_crc,
     parameter::{
-        decode_string_bytes, BrokerState, DefaultSlotValue, DhcpMode, DiscoveryCountStatus,
-        DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode, EndpointType, IdentifyMode, Ipv4Address,
-        Ipv4Route, Ipv6Address, LampOnMode, LampState, MergeMode, NetworkInterface,
+        decode_string_bytes, BrokerState, DefaultSlotValue, DeviceInfo, DhcpMode, DiscoveryCountStatus,
+        DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode, EndpointType, IdentifyMode, IdentifyTimeout,
+        Ipv4Address, Ipv4Route, Ipv6Address, LampOnMode, LampState, MergeMode, NetworkInterface,
         ParameterDescription, ParameterId, PinCode, PowerState, PresetPlaybackMode,
-        PresetProgrammed, ProductCategory, ProductDetail, ProtocolVersion, SelfTest,
-        SensorDefinition, SensorValue, SlotInfo, StaticConfigType, StatusMessage, StatusType,
+        PresetProgrammed, ProductDetail, SelfTest, SensorDefinition, SensorType, SensorUnit,
+        SensorValue, ShippingLockState, SlotInfo, StaticConfigType, StatusMessage, StatusType,
         SupportedTimes, TimeMode,
     },
     CommandClass, DeviceUID, EncodedFrame, EncodedParameterData, RdmError, SubDeviceId,
@@ -277,18 +277,7 @@ pub enum ResponseParameterData {
         #[cfg(not(feature = "alloc"))] Vec<u16, 115>,
     ),
     GetParameterDescription(ParameterDescription),
-    GetDeviceInfo {
-        protocol_version: ProtocolVersion,
-        model_id: u16,
-        product_category: ProductCategory,
-        software_version_id: u32,
-        footprint: u16,
-        current_personality: u8,
-        personality_count: u8,
-        start_address: u16,
-        sub_device_count: u16,
-        sensor_count: u8,
-    },
+    GetDeviceInfo(DeviceInfo),
     GetProductDetailIdList(
         #[cfg(feature = "alloc")] Vec<ProductDetail>,
         #[cfg(not(feature = "alloc"))] Vec<ProductDetail, 115>,
@@ -545,6 +534,86 @@ pub enum ResponseParameterData {
         #[cfg(not(feature = "alloc"))] String<63>,
     ),
     GetDnsDomainName(
+        #[cfg(feature = "alloc")] String,
+        #[cfg(not(feature = "alloc"))] String<231>,
+    ),
+    // E1.37-5
+    GetIdentifyTimeout(IdentifyTimeout),
+    GetManufacturerUrl(
+        #[cfg(feature = "alloc")] String,
+        #[cfg(not(feature = "alloc"))] String<231>,
+    ),
+    GetProductUrl(
+        #[cfg(feature = "alloc")] String,
+        #[cfg(not(feature = "alloc"))] String<231>,
+    ),
+    GetFirmwareUrl(
+        #[cfg(feature = "alloc")] String,
+        #[cfg(not(feature = "alloc"))] String<231>,
+    ),
+    GetShippingLock(ShippingLockState),
+    GetPowerOffReady(bool),
+    GetSerialNumber(
+        #[cfg(feature = "alloc")] String,
+        #[cfg(not(feature = "alloc"))] String<231>,
+    ),
+    GetTestData(
+        #[cfg(feature = "alloc")] Vec<u8>,
+        #[cfg(not(feature = "alloc"))] Vec<u8, 231>,
+    ),
+    SetTestData(
+        #[cfg(feature = "alloc")] Vec<u8>,
+        #[cfg(not(feature = "alloc"))] Vec<u8, 231>,
+    ),
+    GetCommsStatusNSC {
+        checksum: Option<u32>,
+        packet_count: Option<u32>,
+        most_recent_slot_count: Option<u16>,
+        minimum_slot_count: Option<u16>,
+        maximum_slot_count: Option<u16>,
+        packet_error_count: Option<u32>,
+    },
+    // GetResponderTags // TODO
+    CheckResponderTag(bool),
+    /// Unit number of 0 is unset
+    GetDeviceUnitNumber(u32),
+    GetDmxPersonalityId {
+        personality: u8,
+        major_id: u16,
+        minor_id: u16
+    },
+    GetDeviceInfoOffstage {
+        root_personality: u8,
+        sub_device_id: SubDeviceId,
+        sub_device_personality: u8,
+        info: DeviceInfo,
+    },
+    GetSensorTypeCustom {
+        /// Should be manufacturer specific
+        sensor_type: SensorType,
+        #[cfg(feature = "alloc")]
+        label: String,
+        #[cfg(not(feature = "alloc"))]
+        label: String<32>,
+    },
+    GetSensorUnitCustom {
+        /// Should be manufacturer specific
+        sensor_unit: SensorUnit,
+        #[cfg(feature = "alloc")]
+        label: String,
+        #[cfg(not(feature = "alloc"))]
+        label: String<32>,
+    },
+    GetMetadataParameterVersion {
+        parameter_id: ParameterId,
+        version: u16,
+    },
+    GetMetadataJson {
+        parameter_id: Option<ParameterId>,
+        #[cfg(feature = "alloc")] json_text: String,
+        #[cfg(not(feature = "alloc"))] json_text: String<231>,
+    },
+    GetMetadataJsonUrl(
         #[cfg(feature = "alloc")] String,
         #[cfg(not(feature = "alloc"))] String<231>,
     ),
@@ -854,45 +923,8 @@ impl ResponseParameterData {
                 #[cfg(not(feature = "alloc"))]
                 buf.extend(description.description.bytes());
             }
-            Self::GetDeviceInfo {
-                protocol_version,
-                model_id,
-                product_category,
-                software_version_id,
-                footprint,
-                current_personality,
-                personality_count,
-                start_address,
-                sub_device_count,
-                sensor_count,
-            } => {
-                #[cfg(feature = "alloc")]
-                buf.reserve(21);
-
-                buf.extend(u16::from(*protocol_version).to_be_bytes());
-
-                buf.extend(model_id.to_be_bytes());
-                buf.extend(u16::from(*product_category).to_be_bytes());
-                buf.extend(software_version_id.to_be_bytes());
-                buf.extend(footprint.to_be_bytes());
-
-                #[cfg(feature = "alloc")]
-                buf.push(*current_personality);
-                #[cfg(not(feature = "alloc"))]
-                buf.push(*current_personality).unwrap();
-
-                #[cfg(feature = "alloc")]
-                buf.push(*personality_count);
-                #[cfg(not(feature = "alloc"))]
-                buf.push(*personality_count).unwrap();
-
-                buf.extend(start_address.to_be_bytes());
-                buf.extend(sub_device_count.to_be_bytes());
-
-                #[cfg(feature = "alloc")]
-                buf.push(*sensor_count);
-                #[cfg(not(feature = "alloc"))]
-                buf.push(*sensor_count).unwrap();
+            Self::GetDeviceInfo(info) => {
+                info.encode(&mut buf);
             }
             Self::GetProductDetailIdList(details) => {
                 #[cfg(feature = "alloc")]
@@ -1774,6 +1806,187 @@ impl ResponseParameterData {
 
                 buf.extend(domain_name.bytes());
             }
+            // E1.37-5
+            Self::GetIdentifyTimeout(identify_timeout) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(2);
+
+                buf.extend(u16::from(*identify_timeout).to_be_bytes());
+            }
+            Self::GetManufacturerUrl(url) |
+            Self::GetProductUrl(url) |
+            Self::GetFirmwareUrl(url) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(url.len());
+
+                buf.extend(url.bytes());
+            }
+            Self::GetShippingLock(lock) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push((*lock) as u8);
+                #[cfg(not(feature = "alloc"))]
+                buf.push((*lock) as u8).unwrap();
+            }
+            Self::GetPowerOffReady(ready) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push(if *ready {1} else {0});
+                #[cfg(not(feature = "alloc"))]
+                buf.push(if *ready {1} else {0}).unwrap();
+            }
+            Self::GetSerialNumber(num) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(num.len());
+
+                buf.extend(num.bytes());
+            }
+            Self::GetTestData(data) | Self::SetTestData(data) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(data.len());
+
+                #[cfg(feature = "alloc")]
+                buf.extend(data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(data).unwrap();
+            }
+            Self::GetCommsStatusNSC {
+                checksum,
+                packet_count,
+                most_recent_slot_count,
+                minimum_slot_count,
+                maximum_slot_count,
+                packet_error_count
+            } => {
+                let supported: u8 = 
+                    if checksum.is_some() {0x01} else {0} |
+                    if packet_count.is_some() {0x02} else {0} |
+                    if most_recent_slot_count.is_some() {0x04} else {0} |
+                    if minimum_slot_count.is_some() {0x08} else {0} |
+                    if maximum_slot_count.is_some() {0x10} else {0} |
+                    if packet_error_count.is_some() {0x20} else {0};
+                
+                #[cfg(feature = "alloc")]
+                buf.reserve(19);
+
+                #[cfg(feature = "alloc")]
+                buf.push(supported);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(supported).unwrap();
+
+                buf.extend(checksum.unwrap_or(0).to_be_bytes());
+                buf.extend(packet_count.unwrap_or(0).to_be_bytes());
+                buf.extend(most_recent_slot_count.unwrap_or(0).to_be_bytes());
+                buf.extend(minimum_slot_count.unwrap_or(0).to_be_bytes());
+                buf.extend(maximum_slot_count.unwrap_or(0).to_be_bytes());
+                buf.extend(packet_error_count.unwrap_or(0).to_be_bytes());
+            }
+            Self::CheckResponderTag(present) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push(if *present {1} else {0});
+                #[cfg(not(feature = "alloc"))]
+                buf.push(if *present {1} else {0}).unwrap();
+            }
+            Self::GetDeviceUnitNumber(num) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4);
+
+                buf.extend((*num).to_be_bytes());
+            }
+            Self::GetDmxPersonalityId {
+                personality,
+                major_id,
+                minor_id
+            } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(5);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*personality);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*personality).unwrap();
+
+                buf.extend((*major_id).to_be_bytes());
+                buf.extend((*minor_id).to_be_bytes());
+            }
+            Self::GetDeviceInfoOffstage {
+                root_personality,
+                sub_device_id,
+                sub_device_personality,
+                info
+            } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4+19);
+
+                #[cfg(feature = "alloc")]
+                buf.push(*root_personality);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*root_personality).unwrap();
+
+                buf.extend(u16::from(*sub_device_id).to_be_bytes());
+
+                #[cfg(feature = "alloc")]
+                buf.push(*sub_device_personality);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*sub_device_personality).unwrap();
+
+                info.encode(&mut buf);
+            }
+            Self::GetSensorTypeCustom { sensor_type, label } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1+label.len());
+
+                #[cfg(feature = "alloc")]
+                buf.push((*sensor_type).into());
+                #[cfg(not(feature = "alloc"))]
+                buf.push((*sensor_type).into()).unwrap();
+
+                buf.extend(label.bytes());
+            }
+            Self::GetSensorUnitCustom { sensor_unit, label } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1+label.len());
+
+                #[cfg(feature = "alloc")]
+                buf.push((*sensor_unit).into());
+                #[cfg(not(feature = "alloc"))]
+                buf.push((*sensor_unit).into()).unwrap();
+
+                buf.extend(label.bytes());
+            }
+            Self::GetMetadataParameterVersion { parameter_id, version } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4);
+
+                buf.extend(u16::from(*parameter_id).to_be_bytes());
+                buf.extend((*version).to_be_bytes());
+            }
+            Self::GetMetadataJson { parameter_id, json_text } => {
+                if let Some(pid) = parameter_id {
+                    #[cfg(feature = "alloc")]
+                    buf.reserve(2+json_text.len());
+
+                    buf.extend(u16::from(*pid).to_be_bytes());
+                } else {
+                    #[cfg(feature = "alloc")]
+                    buf.reserve(json_text.len());
+                }
+
+                buf.extend(json_text.bytes());
+            }
+            Self::GetMetadataJsonUrl(url) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(url.len());
+
+                buf.extend(url.bytes());
+            }
             // E1.37-7
             Self::GetEndpointList {
                 list_change_number,
@@ -2254,18 +2467,9 @@ impl ResponseParameterData {
             }
             (CommandClass::GetCommandResponse, ParameterId::DeviceInfo) => {
                 check_msg_len!(bytes, 19);
-                Ok(Self::GetDeviceInfo {
-                    protocol_version: ProtocolVersion::new(bytes[0], bytes[1]),
-                    model_id: u16::from_be_bytes(bytes[2..=3].try_into()?),
-                    product_category: u16::from_be_bytes(bytes[4..=5].try_into()?).into(),
-                    software_version_id: u32::from_be_bytes(bytes[6..=9].try_into()?),
-                    footprint: u16::from_be_bytes(bytes[10..=11].try_into()?),
-                    current_personality: bytes[12],
-                    personality_count: bytes[13],
-                    start_address: u16::from_be_bytes(bytes[14..=15].try_into()?),
-                    sub_device_count: u16::from_be_bytes(bytes[16..=17].try_into()?),
-                    sensor_count: u8::from_be(bytes[18]),
-                })
+                Ok(Self::GetDeviceInfo(
+                    DeviceInfo::decode(bytes)?
+                ))
             }
             (CommandClass::GetCommandResponse, ParameterId::ProductDetailIdList) => {
                 Ok(Self::GetProductDetailIdList(
@@ -2813,6 +3017,125 @@ impl ResponseParameterData {
             (CommandClass::GetCommandResponse, ParameterId::DnsDomainName) => {
                 Ok(Self::GetDnsHostName(decode_string_bytes(&bytes[..bytes.len().min(231)])?))
             },
+            // E1.37-5
+            (CommandClass::GetCommandResponse, ParameterId::IdentifyTimeout) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetIdentifyTimeout(
+                    u16::from_be_bytes([bytes[0], bytes[1]]).into()
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::ManufacturerUrl) => {
+                Ok(Self::GetManufacturerUrl(decode_string_bytes(&bytes[..bytes.len().min(231)])?))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::ProductUrl) => {
+                Ok(Self::GetProductUrl(decode_string_bytes(&bytes[..bytes.len().min(231)])?))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::FirmwareUrl) => {
+                Ok(Self::GetFirmwareUrl(decode_string_bytes(&bytes[..bytes.len().min(231)])?))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::ShippingLock) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetShippingLock(
+                    bytes[0].try_into()?
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::PowerOffReady) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetPowerOffReady(
+                    bytes[0] != 0
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::SerialNumber) => {
+                Ok(Self::GetSerialNumber(decode_string_bytes(&bytes[..bytes.len().min(231)])?))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::TestData) => {
+                #[cfg(feature = "alloc")]
+                let r = bytes[..bytes.len().min(231)].into();
+                #[cfg(not(feature = "alloc"))]
+                let r = Vec::<u8, 231>::from_slice(&bytes[..bytes.len().min(231)]).unwrap();
+                Ok(Self::GetTestData(r))
+            }
+            (CommandClass::SetCommandResponse, ParameterId::TestData) => {
+                #[cfg(feature = "alloc")]
+                let r = bytes[..bytes.len().min(231)].into();
+                #[cfg(not(feature = "alloc"))]
+                let r = Vec::<u8, 231>::from_slice(&bytes[..bytes.len().min(231)]).unwrap();
+                Ok(Self::SetTestData(r))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::CommsStatusNsc) => {
+                check_msg_len!(bytes, 19);
+                let present = bytes[0];
+                Ok(Self::GetCommsStatusNSC {
+                    checksum: if present & 0x01 != 0 {
+                        Some(u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]))} else {None},
+                    packet_count: if present & 0x02 != 0 {
+                        Some(u32::from_be_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]))} else {None},
+                    most_recent_slot_count: if present & 0x04 != 0 {
+                        Some(u16::from_be_bytes([bytes[9], bytes[10]]))} else {None},
+                    minimum_slot_count: if present & 0x08 != 0 {
+                        Some(u16::from_be_bytes([bytes[11], bytes[12]]))} else {None},
+                    maximum_slot_count: if present & 0x10 != 0 {
+                        Some(u16::from_be_bytes([bytes[13], bytes[14]]))} else {None},
+                    packet_error_count: if present & 0x20 != 0 {
+                        Some(u32::from_be_bytes([bytes[15], bytes[16], bytes[17], bytes[18]]))} else {None},
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::CheckTag) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::CheckResponderTag(
+                    bytes[0] != 0
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::DeviceUnitNumber) => {
+                check_msg_len!(bytes, 4);
+                Ok(Self::GetDeviceUnitNumber(
+                    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::DmxPersonalityId) => {
+                check_msg_len!(bytes, 5);
+                Ok(Self::GetDmxPersonalityId {
+                    personality: bytes[0],
+                    major_id: u16::from_be_bytes([bytes[1], bytes[2]]),
+                    minor_id: u16::from_be_bytes([bytes[3], bytes[4]]),
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::DeviceInfoOffstage) => {
+                check_msg_len!(bytes, 23);
+                Ok(Self::GetDeviceInfoOffstage {
+                    root_personality: bytes[0],
+                    sub_device_id: u16::from_be_bytes([bytes[1], bytes[2]]).into(),
+                    sub_device_personality: bytes[3],
+                    info: DeviceInfo::decode(&bytes[4..])?
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::SensorTypeCustom) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetSensorTypeCustom {
+                    sensor_type: bytes[0].try_into()?,
+                    label: decode_string_bytes(&bytes[1..bytes.len().min(1+32)])?,
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::SensorUnitCustom) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetSensorUnitCustom {
+                    sensor_unit: bytes[0].try_into()?,
+                    label: decode_string_bytes(&bytes[1..bytes.len().min(1+32)])?,
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::MetadataParameterVersion) => {
+                check_msg_len!(bytes, 4);
+                Ok(Self::GetMetadataParameterVersion {
+                    parameter_id: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    version: u16::from_be_bytes([bytes[2], bytes[3]])
+                })
+            }
+            // (CommandClass::GetCommandResponse, ParameterId::MetadataJson) => todo!(),
+            (CommandClass::GetCommandResponse, ParameterId::MetadataJsonUrl) => {
+                Ok(Self::GetMetadataJsonUrl(
+                    decode_string_bytes(&bytes[0..bytes.len().min(231)])?
+                ))
+            }
             // E1.37-7
             (CommandClass::GetCommandResponse, ParameterId::EndpointList) => {
                 check_msg_len!(bytes, 4);

--- a/src/rdm/response.rs
+++ b/src/rdm/response.rs
@@ -573,7 +573,12 @@ pub enum ResponseParameterData {
         maximum_slot_count: Option<u16>,
         packet_error_count: Option<u32>,
     },
-    // GetResponderTags // TODO
+    GetResponderTags {
+        #[cfg(feature = "alloc")]
+        tags: Vec<String>,
+        #[cfg(not(feature = "alloc"))]
+        tags: Vec<String<32>, 115>,
+    },
     CheckResponderTag(bool),
     /// Unit number of 0 is unset
     GetDeviceUnitNumber(u32),
@@ -609,9 +614,12 @@ pub enum ResponseParameterData {
         version: u16,
     },
     GetMetadataJson {
-        parameter_id: Option<ParameterId>,
-        #[cfg(feature = "alloc")] json_text: String,
-        #[cfg(not(feature = "alloc"))] json_text: String<231>,
+        /// If this is the first message it will contain the 2-byte PID,
+        /// followed by the start of the JSON string
+        /// 
+        /// Otherwise it will just contain part of the JSON string
+        #[cfg(feature = "alloc")] json_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))] json_data: Vec<u8, 231>,
     },
     GetMetadataJsonUrl(
         #[cfg(feature = "alloc")] String,
@@ -1885,6 +1893,16 @@ impl ResponseParameterData {
                 buf.extend(maximum_slot_count.unwrap_or(0).to_be_bytes());
                 buf.extend(packet_error_count.unwrap_or(0).to_be_bytes());
             }
+            Self::GetResponderTags { tags } => {
+                for t in tags {
+                    buf.extend(t.bytes());
+
+                    #[cfg(feature = "alloc")]
+                    buf.push(0);
+                    #[cfg(not(feature = "alloc"))]
+                    buf.push(0).unwrap();
+                }
+            }
             Self::CheckResponderTag(present) => {
                 #[cfg(feature = "alloc")]
                 buf.reserve(1);
@@ -1968,18 +1986,14 @@ impl ResponseParameterData {
                 buf.extend(u16::from(*parameter_id).to_be_bytes());
                 buf.extend((*version).to_be_bytes());
             }
-            Self::GetMetadataJson { parameter_id, json_text } => {
-                if let Some(pid) = parameter_id {
-                    #[cfg(feature = "alloc")]
-                    buf.reserve(2+json_text.len());
+            Self::GetMetadataJson { json_data } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(json_data.len());
 
-                    buf.extend(u16::from(*pid).to_be_bytes());
-                } else {
-                    #[cfg(feature = "alloc")]
-                    buf.reserve(json_text.len());
-                }
-
-                buf.extend(json_text.bytes());
+                #[cfg(feature = "alloc")]
+                buf.extend(json_data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(json_data).unwrap();
             }
             Self::GetMetadataJsonUrl(url) => {
                 #[cfg(feature = "alloc")]
@@ -3080,6 +3094,23 @@ impl ResponseParameterData {
                         Some(u32::from_be_bytes([bytes[15], bytes[16], bytes[17], bytes[18]]))} else {None},
                 })
             }
+            (CommandClass::GetCommandResponse, ParameterId::ListTags) => {
+                let mut tags = Vec::new();
+                let mut remaining = bytes;
+                while remaining.len() > 0 {
+                    // UTF-8 never produces a null, so this is fine for unicode as well as ASCII
+                    let len = remaining.iter().position(|&x| x==0).unwrap_or(remaining.len());
+
+                    if len != 0 {
+                        // limit string length to 32 bytes, truncate if longer
+                        let tag = decode_string_bytes(&remaining[..len.min(32)])?;
+                        tags.push(tag);
+                    }
+                    remaining = &remaining[(len+1).min(remaining.len())..];
+                }
+
+                Ok(Self::GetResponderTags { tags })
+            }
             (CommandClass::GetCommandResponse, ParameterId::CheckTag) => {
                 check_msg_len!(bytes, 1);
                 Ok(Self::CheckResponderTag(
@@ -3130,7 +3161,13 @@ impl ResponseParameterData {
                     version: u16::from_be_bytes([bytes[2], bytes[3]])
                 })
             }
-            // (CommandClass::GetCommandResponse, ParameterId::MetadataJson) => todo!(),
+            (CommandClass::GetCommandResponse, ParameterId::MetadataJson) => {
+                #[cfg(feature = "alloc")]
+                let json_data = bytes[..bytes.len().min(231)].to_vec();
+                #[cfg(not(feature = "alloc"))]
+                let json_data = Vec::<u8, 231>::from_slice(&bytes[..bytes.len().min(231)]).unwrap();
+                Ok(Self::GetMetadataJson { json_data })
+            },
             (CommandClass::GetCommandResponse, ParameterId::MetadataJsonUrl) => {
                 Ok(Self::GetMetadataJsonUrl(
                     decode_string_bytes(&bytes[0..bytes.len().min(231)])?


### PR DESCRIPTION
Finally got around to doing this.

Currently missing:
- Response for 'GetResponderTags' (null-separated list of strings)
- Response for 'GetParameterJson' (first message has a header field that follow-ups don't)

For the parameter JSON, I have previously used a heuristic where the first two bytes are a manufacturer-specific pid (0x8000 bit set) and the next character is a `{`, but this was for passive analysis tooling so there's certainly a beter way here.