### PR TITLE
chore: release v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "dmx512-rdm-protocol"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "heapless",
  "macaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dmx512-rdm-protocol"
 description = "DMX512 and Remote Device Management (RDM) protocol written in Rust"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.81.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `dmx512-rdm-protocol`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).