### PR TITLE
Updates for E1.20-2025

### DIFF
--- a/src/rdm/error.rs
+++ b/src/rdm/error.rs
@@ -38,6 +38,8 @@ pub enum RdmError {
     InvalidEndpointMode(u8),
     InvalidEndpointType(u8),
     InvalidShippingLockState(u8),
+    InvalidSubscriptionAction(u8),
+    InvalidSelfTestStatus(u8),
     MalformedPacket,
 }
 
@@ -140,6 +142,12 @@ impl fmt::Display for RdmError {
             Self::InvalidEndpointType(endpoint_type) => write!(f, "Invalid EndpointType: {}", endpoint_type),
             Self::InvalidShippingLockState(shipping_lock_state) => {
                 write!(f, "Invalid ShippingLockState: {}", shipping_lock_state)
+            }
+            Self::InvalidSubscriptionAction(sub_action) => {
+                write!(f, "Invalid SubscriptionAction: {}", sub_action)
+            }
+            Self::InvalidSelfTestStatus(status) => {
+                write!(f, "Invalid SelfTestStatus: {}", status)
             }
             Self::MalformedPacket => write!(f, "Malformed packet"),
         }

--- a/src/rdm/mod.rs
+++ b/src/rdm/mod.rs
@@ -146,7 +146,7 @@ impl From<DeviceUID> for [u8; 6] {
 pub fn bsd_16_crc(packet: &[u8]) -> u16 {
     packet
         .iter()
-        .fold(0_u16, |sum, byte| (sum.overflowing_add(*byte as u16).0))
+        .fold(0_u16, |sum, byte| sum.wrapping_add(*byte as u16))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/src/rdm/parameter.rs
+++ b/src/rdm/parameter.rs
@@ -47,8 +47,15 @@ pub enum ParameterId {
     StatusIdDescription,
     ClearStatusId,
     SubDeviceIdStatusReportThreshold,
+    QueuedMessageSensorSubscribe,
     SupportedParameters,
     ParameterDescription,
+    SupportedParametersEnhanced,
+    ControllerFlagSupport,
+    NackDescription,
+    PackedPidSub,
+    PackedPidIndex,
+    EnumLabel,
     DeviceInfo,
     ProductDetailIdList,
     DeviceModelDescription,
@@ -86,6 +93,7 @@ pub enum ParameterId {
     PowerState,
     PerformSelfTest,
     SelfTestDescription,
+    SelfTestEnhanced,
     CapturePreset,
     PresetPlayback,
     // E1.37-1 2012r2022 Table A-1
@@ -189,8 +197,15 @@ impl From<u16> for ParameterId {
             0x0031 => Self::StatusIdDescription,
             0x0032 => Self::ClearStatusId,
             0x0033 => Self::SubDeviceIdStatusReportThreshold,
+            0x0034 => Self::QueuedMessageSensorSubscribe,
             0x0050 => Self::SupportedParameters,
             0x0051 => Self::ParameterDescription,
+            0x0055 => Self::SupportedParametersEnhanced,
+            0x0056 => Self::ControllerFlagSupport,
+            0x0057 => Self::NackDescription,
+            0x0058 => Self::PackedPidSub,
+            0x0059 => Self::PackedPidIndex,
+            0x005a => Self::EnumLabel,
             0x0060 => Self::DeviceInfo,
             0x0070 => Self::ProductDetailIdList,
             0x0080 => Self::DeviceModelDescription,
@@ -228,6 +243,7 @@ impl From<u16> for ParameterId {
             0x1010 => Self::PowerState,
             0x1020 => Self::PerformSelfTest,
             0x1021 => Self::SelfTestDescription,
+            0x1022 => Self::SelfTestEnhanced,
             0x1030 => Self::CapturePreset,
             0x1031 => Self::PresetPlayback,
             // E1.37-1
@@ -333,8 +349,15 @@ impl From<ParameterId> for u16 {
             ParameterId::StatusIdDescription => 0x0031,
             ParameterId::ClearStatusId => 0x0032,
             ParameterId::SubDeviceIdStatusReportThreshold => 0x0033,
+            ParameterId::QueuedMessageSensorSubscribe => 0x0034,
             ParameterId::SupportedParameters => 0x0050,
             ParameterId::ParameterDescription => 0x0051,
+            ParameterId::SupportedParametersEnhanced => 0x0055,
+            ParameterId::ControllerFlagSupport => 0x0056,
+            ParameterId::NackDescription => 0x0057,
+            ParameterId::PackedPidSub => 0x0058,
+            ParameterId::PackedPidIndex => 0x0059,
+            ParameterId::EnumLabel => 0x005a,
             ParameterId::DeviceInfo => 0x0060,
             ParameterId::ProductDetailIdList => 0x0070,
             ParameterId::DeviceModelDescription => 0x0080,
@@ -372,6 +395,7 @@ impl From<ParameterId> for u16 {
             ParameterId::PowerState => 0x1010,
             ParameterId::PerformSelfTest => 0x1020,
             ParameterId::SelfTestDescription => 0x1021,
+            ParameterId::SelfTestEnhanced => 0x1022,
             ParameterId::CapturePreset => 0x1030,
             ParameterId::PresetPlayback => 0x1031,
             // E1.37-1
@@ -568,6 +592,8 @@ pub enum ProductDetail {
     GfiRcd,
     Battery,
     ControllableBreaker,
+    Input,
+    Sensor,
     Other,
     ManufacturerSpecific(u16),
     Unknown(u16),
@@ -655,6 +681,8 @@ impl From<u16> for ProductDetail {
             0x0a00 => Self::GfiRcd,
             0x0a01 => Self::Battery,
             0x0a02 => Self::ControllableBreaker,
+            0x0b00 => Self::Input,
+            0x0b01 => Self::Sensor,
             0x7fff => Self::Other,
             value if (0x8000..=0xdfff).contains(&value) => Self::ManufacturerSpecific(value),
             value => Self::Unknown(value),
@@ -744,6 +772,8 @@ impl From<ProductDetail> for u16 {
             ProductDetail::GfiRcd => 0x0a00,
             ProductDetail::Battery => 0x0a01,
             ProductDetail::ControllableBreaker => 0x0a02,
+            ProductDetail::Input => 0x0b00,
+            ProductDetail::Sensor => 0x0b01,
             ProductDetail::Other => 0x7fff,
             ProductDetail::ManufacturerSpecific(value) => value,
             ProductDetail::Unknown(value) => value,
@@ -769,6 +799,41 @@ impl TryFrom<u8> for ImplementedCommandClass {
             0x03 => Ok(Self::GetSet),
             _ => Err(RdmError::InvalidCommandClassImplementation(value)),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ControllerFlags(pub u8);
+impl ControllerFlags {
+    pub fn new() -> Self {
+        Self(0)
+    }
+    pub fn get_unicode_support(self) -> bool {
+        self.0 & 0x01 != 0
+    }
+    pub fn get_hi_res_ack_timer_support(self) -> bool {
+        self.0 & 0x02 != 0
+    }
+    pub fn set_unicode_support(self, value: bool) -> Self {
+        Self(
+            (self.0 & 0xFE) | if value {0x01} else {0}
+        )
+    }
+    pub fn set_hi_res_ack_timer_support(self, value: bool) -> Self {
+        Self(
+            (self.0 & 0xFD) | if value {0x02} else {0}
+        )
+    }
+}
+
+impl From<u8> for ControllerFlags {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+impl From<ControllerFlags> for u8 {
+    fn from(value: ControllerFlags) -> Self {
+        value.0
     }
 }
 
@@ -838,12 +903,22 @@ pub enum ParameterDataType {
     NotDefined,
     BitField,
     Ascii,
-    UnsignedByte,
-    SignedByte,
-    UnsignedWord,
-    SignedWord,
-    UnsignedDWord,
-    SignedDWord,
+    UInt8,
+    Int8,
+    UInt16,
+    Int16,
+    UInt32,
+    Int32,
+    UInt64,
+    Int64,
+    Group,
+    Uid,
+    Boolean,
+    Url,
+    Mac,
+    IpV4,
+    IpV6,
+    Enum,
     ManufacturerSpecific(u8),
 }
 
@@ -855,12 +930,22 @@ impl TryFrom<u8> for ParameterDataType {
             0x00 => Ok(Self::NotDefined),
             0x01 => Ok(Self::BitField),
             0x02 => Ok(Self::Ascii),
-            0x03 => Ok(Self::UnsignedByte),
-            0x04 => Ok(Self::SignedByte),
-            0x05 => Ok(Self::UnsignedWord),
-            0x06 => Ok(Self::SignedWord),
-            0x07 => Ok(Self::UnsignedDWord),
-            0x08 => Ok(Self::SignedDWord),
+            0x03 => Ok(Self::UInt8),
+            0x04 => Ok(Self::Int8),
+            0x05 => Ok(Self::UInt16),
+            0x06 => Ok(Self::Int16),
+            0x07 => Ok(Self::UInt32),
+            0x08 => Ok(Self::Int32),
+            0x09 => Ok(Self::UInt64),
+            0x0a => Ok(Self::Int64),
+            0x0b => Ok(Self::Group),
+            0x0c => Ok(Self::Uid),
+            0x0d => Ok(Self::Boolean),
+            0x0e => Ok(Self::Url),
+            0x0f => Ok(Self::Mac),
+            0x10 => Ok(Self::IpV4),
+            0x11 => Ok(Self::IpV6),
+            0x12 => Ok(Self::Enum),
             n if (0x80..=0xdf).contains(&n) => Ok(Self::ManufacturerSpecific(n)),
             _ => Err(RdmError::InvalidParameterDataType(value)),
         }
@@ -873,12 +958,22 @@ impl From<ParameterDataType> for u8 {
             ParameterDataType::NotDefined => 0x00,
             ParameterDataType::BitField => 0x01,
             ParameterDataType::Ascii => 0x02,
-            ParameterDataType::UnsignedByte => 0x03,
-            ParameterDataType::SignedByte => 0x04,
-            ParameterDataType::UnsignedWord => 0x05,
-            ParameterDataType::SignedWord => 0x06,
-            ParameterDataType::UnsignedDWord => 0x07,
-            ParameterDataType::SignedDWord => 0x08,
+            ParameterDataType::UInt8 => 0x03,
+            ParameterDataType::Int8 => 0x04,
+            ParameterDataType::UInt16 => 0x05,
+            ParameterDataType::Int16 => 0x06,
+            ParameterDataType::UInt32 => 0x07,
+            ParameterDataType::Int32 => 0x08,
+            ParameterDataType::UInt64 => 0x09,
+            ParameterDataType::Int64 => 0x0a,
+            ParameterDataType::Group => 0x0b,
+            ParameterDataType::Uid => 0x0c,
+            ParameterDataType::Boolean => 0x0d,
+            ParameterDataType::Url => 0x0e,
+            ParameterDataType::Mac => 0x0f,
+            ParameterDataType::IpV4 => 0x10,
+            ParameterDataType::IpV6 => 0x11,
+            ParameterDataType::Enum => 0x12,
             ParameterDataType::ManufacturerSpecific(n) => n,
         }
     }
@@ -886,12 +981,12 @@ impl From<ParameterDataType> for u8 {
 
 // E1.20 2025 Section 10.4.2
 pub enum ConvertedParameterValue {
-    UnsignedByte(u8),
-    SignedByte(i8),
-    UnsignedWord(u16),
-    SignedWord(i16),
-    UnsignedDWord(u32),
-    SignedDWord(i32),
+    UInt8(u8),
+    Int8(i8),
+    UInt16(u16),
+    Int16(i16),
+    UInt32(u32),
+    Int32(i32),
     Raw([u8; 4]),
 }
 
@@ -918,27 +1013,32 @@ impl ParameterDescription {
         value: [u8; 4],
     ) -> Result<ConvertedParameterValue, RdmError> {
         match parameter_data_type {
-            ParameterDataType::UnsignedByte => Ok(ConvertedParameterValue::UnsignedByte(value[3])),
-            ParameterDataType::SignedByte => {
-                Ok(ConvertedParameterValue::SignedByte(value[3] as i8))
+            ParameterDataType::UInt8 => Ok(ConvertedParameterValue::UInt8(value[3])),
+            ParameterDataType::Int8 => {
+                Ok(ConvertedParameterValue::Int8(value[3] as i8))
             }
-            ParameterDataType::UnsignedWord => {
-                Ok(ConvertedParameterValue::UnsignedWord(u16::from_be_bytes([
+            ParameterDataType::UInt16 => {
+                Ok(ConvertedParameterValue::UInt16(u16::from_be_bytes([
                     value[2], value[3],
                 ])))
             }
-            ParameterDataType::SignedWord => {
-                Ok(ConvertedParameterValue::SignedWord(i16::from_be_bytes([
+            ParameterDataType::Int16 => {
+                Ok(ConvertedParameterValue::Int16(i16::from_be_bytes([
                     value[2], value[3],
                 ])))
             }
-            ParameterDataType::UnsignedDWord => Ok(ConvertedParameterValue::UnsignedDWord(
+            ParameterDataType::UInt32 => Ok(ConvertedParameterValue::UInt32(
                 u32::from_be_bytes(value),
             )),
-            ParameterDataType::SignedDWord => Ok(ConvertedParameterValue::SignedDWord(
+            ParameterDataType::Int32 => Ok(ConvertedParameterValue::Int32(
                 i32::from_be_bytes(value),
             )),
             ParameterDataType::BitField | ParameterDataType::Ascii |
+            ParameterDataType::UInt64 | ParameterDataType::Int64 |
+            ParameterDataType::Group | ParameterDataType::Uid |
+            ParameterDataType::Boolean | ParameterDataType::Url |
+            ParameterDataType::Mac | ParameterDataType::IpV4 |
+            ParameterDataType::IpV6 | ParameterDataType::Enum |
             ParameterDataType::NotDefined | ParameterDataType::ManufacturerSpecific(..) => {
                 Ok(ConvertedParameterValue::Raw(value))
             }
@@ -1217,7 +1317,7 @@ impl TryFrom<u8> for LampState {
             0x02 => Ok(Self::LampStrike),
             0x03 => Ok(Self::LampStandby),
             0x04 => Ok(Self::LampNotPresent),
-            0x05 => Ok(Self::LampError),
+            0x7F => Ok(Self::LampError),
             n if (0x80..=0xdf).contains(&n) => Ok(Self::ManufacturerSpecific(n)),
             _ => Err(RdmError::InvalidLampState(value)),
         }
@@ -1232,7 +1332,7 @@ impl From<LampState> for u8 {
             LampState::LampStrike => 0x02,
             LampState::LampStandby => 0x03,
             LampState::LampNotPresent => 0x04,
-            LampState::LampError => 0x05,
+            LampState::LampError => 0x7F,
             LampState::ManufacturerSpecific(n) => n,
         }
     }
@@ -1385,6 +1485,94 @@ impl From<SelfTest> for u8 {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SelfTestStatus {
+    NotSupported = 0x00,
+    NotRun = 0x01,
+    Aborted = 0x02,
+    Active = 0x03,
+    Pass = 0x04,
+    Fail = 0x05,
+    NoAnalysis = 0x06,
+    ResultCode = 0x07,
+    Other = 0xFF,
+}
+
+impl TryFrom<u8> for SelfTestStatus {
+    type Error = RdmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(SelfTestStatus::NotSupported),
+            0x01 => Ok(SelfTestStatus::NotRun),
+            0x02 => Ok(SelfTestStatus::Aborted),
+            0x03 => Ok(SelfTestStatus::Active),
+            0x04 => Ok(SelfTestStatus::Pass),
+            0x05 => Ok(SelfTestStatus::Fail),
+            0x06 => Ok(SelfTestStatus::NoAnalysis),
+            0x07 => Ok(SelfTestStatus::ResultCode),
+            0xFF => Ok(SelfTestStatus::Other),
+            _ => Err(RdmError::InvalidSelfTestStatus(value)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelfTestCapability(pub u16);
+impl SelfTestCapability {
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    pub fn get_auto_terminates(&self) -> bool {
+        self.0 & 0x01 != 0
+    }
+    pub fn get_restricts_dmx(&self) -> bool {
+        self.0 & 0x02 != 0
+    }
+    pub fn get_restricts_rdm(&self) -> bool {
+        self.0 & 0x04 != 0
+    }
+    pub fn get_all_test_ignores_termination(&self) -> bool {
+        self.0 & 0x08 != 0
+    }
+    pub fn get_result_code_available(&self) -> bool {
+        self.0 & 0x10 != 0
+    }
+    pub fn get_generates_status_messages(&self) -> bool {
+        self.0 & 0x20 != 0
+    }
+    pub fn set_auto_terminates(self, value: bool) -> Self {
+        Self(self.0 & !0x01 | if value {0x01} else {0})
+    }
+    pub fn set_restricts_dmx(self, value: bool) -> Self {
+        Self(self.0 & !0x02 | if value {0x02} else {0})
+    }
+    pub fn set_restricts_rdm(self, value: bool) -> Self {
+        Self(self.0 & !0x04 | if value {0x04} else {0})
+    }
+    pub fn set_all_test_ignores_termination(self, value: bool) -> Self {
+        Self(self.0 & !0x08 | if value {0x08} else {0})
+    }
+    pub fn set_result_code_available(self, value: bool) -> Self {
+        Self(self.0 & !0x10 | if value {0x10} else {0})
+    }
+    pub fn set_generates_status_messages(self, value: bool) -> Self {
+        Self(self.0 & !0x20 | if value {0x20} else {0})
+    }
+}
+
+impl From<u16> for SelfTestCapability {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+impl From<SelfTestCapability> for u16 {
+    fn from(value: SelfTestCapability) -> Self {
+        value.0
+    }
+}
+
 // E1.20 2025 Table A-7
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum PresetPlaybackMode {
@@ -1427,8 +1615,11 @@ pub enum StatusMessageIdDefinition {
     CalibrationFailed = 0x0001,
     SensorNotFound = 0x0002,
     SensorAlwaysOn = 0x0003,
+    FeedbackError = 0x0004,
     LampDoused = 0x0011,
     LampStrike = 0x0012,
+    LampAccessOpen = 0x0013,
+    LampAlwaysOn = 0x0014,
     OverTemperature = 0x0021,
     UnderTemperature = 0x0022,
     SensorOutOfRange = 0x0023,
@@ -1445,9 +1636,20 @@ pub enum StatusMessageIdDefinition {
     Watts = 0x0043,
     DimmerFailure = 0x0044,
     DimmerPanic = 0x0045,
+    LoadFailure = 0x0046,
     Ready = 0x0050,
     NotReady = 0x0051,
     LowFluid = 0x0052,
+    EepromError = 0x0060,
+    RamError = 0x0061,
+    FpgaError = 0x0062,
+    ProxyBroadcastDropped = 0x0070,
+    AscRxOk = 0x0071,
+    AscDropped = 0x0072,
+    DmxNscNone = 0x0080,
+    DmxNscLoss = 0x0081,
+    DmxNscError = 0x0082,
+    DmxNscOk = 0x0083,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1460,7 +1662,7 @@ pub struct StatusMessage {
     #[cfg(feature = "alloc")]
     pub description: Option<String>,
     #[cfg(not(feature = "alloc"))]
-    pub description: Option<String<32>>,
+    pub description: Option<String<64>>,
 }
 
 impl StatusMessage {
@@ -1477,7 +1679,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} failed calibration", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} failed calibration", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
@@ -1488,7 +1690,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} sensor not found", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} sensor not found", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
@@ -1499,8 +1701,19 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} sensor always on", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} sensor always on", SlotIdDefinition::from(data_value1))
+                            .as_str()
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                ),
+                0x0004 => Some(
+                    #[cfg(feature = "alloc")]
+                    format!("{} feedback error", SlotIdDefinition::from(data_value1)),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str(
+                        format_args!("{} feedback error", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
                     )
@@ -1510,13 +1723,25 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     "Lamp Doused".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("Lamp Doused").unwrap(),
+                    String::<64>::from_str("Lamp Doused").unwrap(),
                 ),
                 0x0012 => Some(
                     #[cfg(feature = "alloc")]
-                    "Lamp Strike".to_string(),
+                    "Lamp failed to strike".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("Lamp Strike").unwrap(),
+                    String::<64>::from_str("Lamp failed to strike").unwrap(),
+                ),
+                0x0013 => Some(
+                    #[cfg(feature = "alloc")]
+                    "Lamp access open".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("Lamp access open").unwrap(),
+                ),
+                0x0014 => Some(
+                    #[cfg(feature = "alloc")]
+                    "Lamp stuck on".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("Lamp stuck on").unwrap(),
                 ),
                 0x0021 => Some(
                     #[cfg(feature = "alloc")]
@@ -1525,7 +1750,7 @@ impl StatusMessage {
                         data_value1, data_value2
                     ),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!(
                             "Sensor {} over temp at {} degrees C",
                             data_value1, data_value2
@@ -1542,7 +1767,7 @@ impl StatusMessage {
                         data_value1, data_value2
                     ),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!(
                             "Sensor {} under temp at {} degrees C",
                             data_value1, data_value2
@@ -1556,7 +1781,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Sensor {} out of range", data_value1),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Sensor {} out of range", data_value1)
                             .as_str()
                             .unwrap(),
@@ -1567,7 +1792,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} over voltage at {} V", data_value1, data_value2),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} over voltage at {} V", data_value1, data_value2)
                             .as_str()
                             .unwrap(),
@@ -1578,7 +1803,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} under voltage at {} V", data_value1, data_value2),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} under voltage at {} V", data_value1, data_value2)
                             .as_str()
                             .unwrap(),
@@ -1589,7 +1814,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} over current at {} A", data_value1, data_value2),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} over current at {} A", data_value1, data_value2)
                             .as_str()
                             .unwrap(),
@@ -1600,7 +1825,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} under current at {} A", data_value1, data_value2),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} under current at {} A", data_value1, data_value2)
                             .as_str()
                             .unwrap(),
@@ -1611,7 +1836,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} is at {} degrees", data_value1, data_value2),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} is at {} degrees", data_value1, data_value2)
                             .as_str()
                             .unwrap(),
@@ -1622,7 +1847,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("Phase {} Error", data_value1),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("Phase {} Error", data_value1)
                             .as_str()
                             .unwrap(),
@@ -1633,52 +1858,58 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} Amps", data_value1),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(format_args!("{} Amps", data_value1).as_str().unwrap())
+                    String::<64>::from_str(format_args!("{} Amps", data_value1).as_str().unwrap())
                         .unwrap(),
                 ),
                 0x0038 => Some(
                     #[cfg(feature = "alloc")]
                     format!("{} Volts", data_value1),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(format_args!("{} Volts", data_value1).as_str().unwrap())
+                    String::<64>::from_str(format_args!("{} Volts", data_value1).as_str().unwrap())
                         .unwrap(),
                 ),
                 0x0041 => Some(
                     #[cfg(feature = "alloc")]
                     "No Dimmer".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("No Dimmer").unwrap(),
+                    String::<64>::from_str("No Dimmer").unwrap(),
                 ),
                 0x0042 => Some(
                     #[cfg(feature = "alloc")]
                     "Tripped Breaker".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("Tripped Breaker").unwrap(),
+                    String::<64>::from_str("Tripped Breaker").unwrap(),
                 ),
                 0x0043 => Some(
                     #[cfg(feature = "alloc")]
                     format!("{} Watts", data_value1),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(format_args!("{} Watts", data_value1).as_str().unwrap())
+                    String::<64>::from_str(format_args!("{} Watts", data_value1).as_str().unwrap())
                         .unwrap(),
                 ),
                 0x0044 => Some(
                     #[cfg(feature = "alloc")]
                     "Dimmer Failure".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("Dimmer Failure").unwrap(),
+                    String::<64>::from_str("Dimmer Failure").unwrap(),
                 ),
                 0x0045 => Some(
                     #[cfg(feature = "alloc")]
                     "Panic Mode".to_string(),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str("Panic Mode").unwrap(),
+                    String::<64>::from_str("Panic Mode").unwrap(),
+                ),
+                0x0046 => Some(
+                    #[cfg(feature = "alloc")]
+                    "Lamp or cable failure".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("Lamp or cable failure").unwrap(),
                 ),
                 0x0050 => Some(
                     #[cfg(feature = "alloc")]
                     format!("{} ready", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} ready", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
@@ -1689,7 +1920,7 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} not ready", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} not ready", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
@@ -1700,12 +1931,87 @@ impl StatusMessage {
                     #[cfg(feature = "alloc")]
                     format!("{} low fluid", SlotIdDefinition::from(data_value1)),
                     #[cfg(not(feature = "alloc"))]
-                    String::<32>::from_str(
+                    String::<64>::from_str(
                         format_args!("{} low fluid", SlotIdDefinition::from(data_value1))
                             .as_str()
                             .unwrap(),
                     )
                     .unwrap(),
+                ),
+                0x0060 => Some(
+                    #[cfg(feature = "alloc")]
+                    "EEPROM error".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("EEPROM error").unwrap(),
+                ),
+                0x0061 => Some(
+                    #[cfg(feature = "alloc")]
+                    "RAM error".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("RAM error").unwrap(),
+                ),
+                0x0062 => Some(
+                    #[cfg(feature = "alloc")]
+                    "FPGA programming error".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("FPGA programming error").unwrap(),
+                ),
+                0x0070 => Some(
+                    #[cfg(feature = "alloc")]
+                    format!("Proxy Drop: PID 0x{:04X} at TN {}", data_value1, data_value2),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str(
+                        format_args!("Proxy Drop: PID 0x{:04X} at TN {}", data_value1, data_value2)
+                            .as_str()
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                ),
+                0x0071 => Some(
+                    #[cfg(feature = "alloc")]
+                    format!("DMX ASC 0x{:02X} received OK", data_value1),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str(
+                        format_args!("DMX ASC 0x{:02X} received OK", data_value1)
+                            .as_str()
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                ),
+                0x0072 => Some(
+                    #[cfg(feature = "alloc")]
+                    format!("DMX ASC 0x{:02X} now dropped", data_value1),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str(
+                        format_args!("DMX ASC 0x{:02X} now dropped", data_value1)
+                            .as_str()
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                ),
+                0x0080 => Some(
+                    #[cfg(feature = "alloc")]
+                    "DMX NSC never received".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("DMX NSC never received").unwrap(),
+                ),
+                0x0081 => Some(
+                    #[cfg(feature = "alloc")]
+                    "DMX NSC received, now dropped".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("DMX NSC received, now dropped").unwrap(),
+                ),
+                0x0082 => Some(
+                    #[cfg(feature = "alloc")]
+                    "DMX NSC timing or packet error".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("DMX NSC timing or packet error").unwrap(),
+                ),
+                0x0083 => Some(
+                    #[cfg(feature = "alloc")]
+                    "DMX NSC received OK".to_string(),
+                    #[cfg(not(feature = "alloc"))]
+                    String::<64>::from_str("DMX NSC received OK").unwrap(),
                 ),
                 _ => None,
             }
@@ -1808,7 +2114,21 @@ pub enum SlotIdDefinition {
     ColorAddBlue,
     ColorCorrection,
     ColorScroll,
+    ColorAddLime,
+    ColorAddIndigo,
+    ColorAddCyan,
+    ColorAddDeepRed,
+    ColorAddDeepBlue,
+    ColorAddNatWhite,
     ColorSemaphore,
+    ColorAddAmber,
+    ColorAddWhite,
+    ColorAddWarmWhite,
+    ColorAddCoolWhite,
+    ColorSubUv,
+    ColorHue,
+    ColorSaturation,
+    ColorAddUv,
     StaticGoboWheel,
     RotoGoboWheel,
     PrismWheel,
@@ -1826,6 +2146,10 @@ pub enum SlotIdDefinition {
     FixtureControl,
     FixtureSpeed,
     Macro,
+    PowerControl,
+    FanControl,
+    HeaterControl,
+    FountainControl,
     Undefined,
     ManufacturerSpecific(u16),
     Unknown(u16),
@@ -1847,7 +2171,21 @@ impl From<u16> for SlotIdDefinition {
             0x0207 => Self::ColorAddBlue,
             0x0208 => Self::ColorCorrection,
             0x0209 => Self::ColorScroll,
+            0x020a => Self::ColorAddLime,
+            0x020b => Self::ColorAddIndigo,
+            0x020c => Self::ColorAddCyan,
+            0x020d => Self::ColorAddDeepRed,
+            0x020e => Self::ColorAddDeepBlue,
+            0x020f => Self::ColorAddNatWhite,
             0x0210 => Self::ColorSemaphore,
+            0x0211 => Self::ColorAddAmber,
+            0x0212 => Self::ColorAddWhite,
+            0x0213 => Self::ColorAddWarmWhite,
+            0x0214 => Self::ColorAddCoolWhite,
+            0x0215 => Self::ColorSubUv,
+            0x0216 => Self::ColorHue,
+            0x0217 => Self::ColorSaturation,
+            0x0218 => Self::ColorAddUv,
             0x0301 => Self::StaticGoboWheel,
             0x0302 => Self::RotoGoboWheel,
             0x0303 => Self::PrismWheel,
@@ -1865,6 +2203,10 @@ impl From<u16> for SlotIdDefinition {
             0x0502 => Self::FixtureControl,
             0x0503 => Self::FixtureSpeed,
             0x0504 => Self::Macro,
+            0x0505 => Self::PowerControl,
+            0x0506 => Self::FanControl,
+            0x0507 => Self::HeaterControl,
+            0x0508 => Self::FountainControl,
             0xffff => Self::Undefined,
             value if (0x8000..=0xffdf).contains(&value) => Self::ManufacturerSpecific(value),
             value => Self::Unknown(value),
@@ -1888,7 +2230,21 @@ impl From<SlotIdDefinition> for u16 {
             SlotIdDefinition::ColorAddBlue => 0x0207,
             SlotIdDefinition::ColorCorrection => 0x0208,
             SlotIdDefinition::ColorScroll => 0x0209,
+            SlotIdDefinition::ColorAddLime => 0x020a,
+            SlotIdDefinition::ColorAddIndigo => 0x020b,
+            SlotIdDefinition::ColorAddCyan => 0x020c,
+            SlotIdDefinition::ColorAddDeepRed => 0x020d,
+            SlotIdDefinition::ColorAddDeepBlue => 0x020e,
+            SlotIdDefinition::ColorAddNatWhite => 0x020f,
             SlotIdDefinition::ColorSemaphore => 0x0210,
+            SlotIdDefinition::ColorAddAmber => 0x0211,
+            SlotIdDefinition::ColorAddWhite => 0x0212,
+            SlotIdDefinition::ColorAddWarmWhite => 0x0213,
+            SlotIdDefinition::ColorAddCoolWhite => 0x0214,
+            SlotIdDefinition::ColorSubUv => 0x0215,
+            SlotIdDefinition::ColorHue => 0x0216,
+            SlotIdDefinition::ColorSaturation => 0x0217,
+            SlotIdDefinition::ColorAddUv => 0x0218,
             SlotIdDefinition::StaticGoboWheel => 0x0301,
             SlotIdDefinition::RotoGoboWheel => 0x0302,
             SlotIdDefinition::PrismWheel => 0x0303,
@@ -1906,6 +2262,10 @@ impl From<SlotIdDefinition> for u16 {
             SlotIdDefinition::FixtureControl => 0x0502,
             SlotIdDefinition::FixtureSpeed => 0x0503,
             SlotIdDefinition::Macro => 0x0504,
+            SlotIdDefinition::PowerControl => 0x0505,
+            SlotIdDefinition::FanControl => 0x0506,
+            SlotIdDefinition::HeaterControl => 0x0507,
+            SlotIdDefinition::FountainControl => 0x0508,
             SlotIdDefinition::Undefined => 0xffff,
             SlotIdDefinition::ManufacturerSpecific(value) => value,
             SlotIdDefinition::Unknown(value) => value,
@@ -1929,7 +2289,21 @@ impl core::fmt::Display for SlotIdDefinition {
             Self::ColorAddBlue => "Color Add Blue",
             Self::ColorCorrection => "Color Correction",
             Self::ColorScroll => "Color Scroll",
+            Self::ColorAddLime => "Color Add Lime",
+            Self::ColorAddIndigo => "Color Add Indigo",
+            Self::ColorAddCyan => "Color Add Cyan",
+            Self::ColorAddDeepRed => "Color Add Deep Red",
+            Self::ColorAddDeepBlue => "Color Add Deep Blue",
+            Self::ColorAddNatWhite => "Color Add Natural White",
             Self::ColorSemaphore => "Color Semaphore",
+            Self::ColorAddAmber => "Color Add Amber",
+            Self::ColorAddWhite => "Color Add White",
+            Self::ColorAddWarmWhite => "Color Add Warm White",
+            Self::ColorAddCoolWhite => "Color Add Cool White",
+            Self::ColorSubUv => "Color Sub UV",
+            Self::ColorHue => "Color Hue",
+            Self::ColorSaturation => "Color Saturation",
+            Self::ColorAddUv => "Color Add UV",
             Self::StaticGoboWheel => "Static Gobo Wheel",
             Self::RotoGoboWheel => "Roto Gobo Wheel",
             Self::PrismWheel => "Prism Wheel",
@@ -1947,6 +2321,10 @@ impl core::fmt::Display for SlotIdDefinition {
             Self::FixtureControl => "Fixture Control",
             Self::FixtureSpeed => "Fixture Speed",
             Self::Macro => "Macro",
+            Self::PowerControl => "Relay or Power Control",
+            Self::FanControl => "Fan Control",
+            Self::HeaterControl => "Heater Control",
+            Self::FountainControl => "Fountain Water Pump Control",
             Self::Undefined => "Undefined",
             Self::ManufacturerSpecific(value) => {
                 return write!(f, "Manufacturer Specific: {}", value)
@@ -2007,6 +2385,14 @@ pub enum SensorType {
     Items,
     Humidity,
     Counter16Bit,
+    CpuLoad,
+    Bandwidth,
+    Concentration,
+    SoundPressureLevel,
+    SolidAngle,
+    LogRatio,
+    LogRatioVolts,
+    LogRatioWatts,
     Other,
     ManufacturerSpecific(u8),
 }
@@ -2048,6 +2434,14 @@ impl TryFrom<u8> for SensorType {
             0x1e => Ok(Self::Items),
             0x1f => Ok(Self::Humidity),
             0x20 => Ok(Self::Counter16Bit),
+            0x21 => Ok(Self::CpuLoad),
+            0x22 => Ok(Self::Bandwidth),
+            0x23 => Ok(Self::Concentration),
+            0x24 => Ok(Self::SoundPressureLevel),
+            0x25 => Ok(Self::SolidAngle),
+            0x26 => Ok(Self::LogRatio),
+            0x27 => Ok(Self::LogRatioVolts),
+            0x28 => Ok(Self::LogRatioWatts),
             0x7f => Ok(Self::Other),
             value if (0x80..=0xff).contains(&value) => Ok(Self::ManufacturerSpecific(value)),
             _ => Err(RdmError::InvalidSensorType(value)),
@@ -2091,6 +2485,14 @@ impl From<SensorType> for u8 {
             SensorType::Items => 0x1e,
             SensorType::Humidity => 0x1f,
             SensorType::Counter16Bit => 0x20,
+            SensorType::CpuLoad => 0x21,
+            SensorType::Bandwidth => 0x22,
+            SensorType::Concentration => 0x23,
+            SensorType::SoundPressureLevel => 0x24,
+            SensorType::SolidAngle => 0x25,
+            SensorType::LogRatio => 0x26,
+            SensorType::LogRatioVolts => 0x27,
+            SensorType::LogRatioWatts => 0x28,
             SensorType::Other => 0x7f,
             SensorType::ManufacturerSpecific(value) => value,
         }
@@ -2130,6 +2532,14 @@ pub enum SensorUnit {
     Lux,
     Ire,
     Byte,
+    Decibel,
+    DecibelVolt,
+    DecibelWatt,
+    DecibelMeter,
+    Percent,
+    MolesPerCubicMeter,
+    Rpm,
+    BytesPerSecond,
     ManufacturerSpecific(u8),
 }
 
@@ -2167,6 +2577,14 @@ impl TryFrom<u8> for SensorUnit {
             0x1a => Ok(Self::Lux),
             0x1b => Ok(Self::Ire),
             0x1c => Ok(Self::Byte),
+            0x1d => Ok(Self::Decibel),
+            0x2e => Ok(Self::DecibelVolt),
+            0x1f => Ok(Self::DecibelWatt),
+            0x20 => Ok(Self::DecibelMeter),
+            0x21 => Ok(Self::Percent),
+            0x22 => Ok(Self::MolesPerCubicMeter),
+            0x23 => Ok(Self::Rpm),
+            0x24 => Ok(Self::BytesPerSecond),
             value if (0x80..=0xff).contains(&value) => Ok(Self::ManufacturerSpecific(value)),
             _ => Err(RdmError::InvalidSensorUnit(value)),
         }
@@ -2205,6 +2623,14 @@ impl From<SensorUnit> for u8 {
             SensorUnit::Lux => 0x1a,
             SensorUnit::Ire => 0x1b,
             SensorUnit::Byte => 0x1c,
+            SensorUnit::Decibel => 0x1d,
+            SensorUnit::DecibelVolt => 0x2e,
+            SensorUnit::DecibelWatt => 0x1f,
+            SensorUnit::DecibelMeter => 0x20,
+            SensorUnit::Percent => 0x21,
+            SensorUnit::MolesPerCubicMeter => 0x22,
+            SensorUnit::Rpm => 0x23,
+            SensorUnit::BytesPerSecond => 0x24,
             SensorUnit::ManufacturerSpecific(value) => value,
         }
     }
@@ -2987,6 +3413,92 @@ impl TryFrom<u8> for ShippingLockState {
             0x02 => Ok(Self::PartiallyLocked),
             _ => Err(RdmError::InvalidShippingLockState(value))
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptionAction {
+    Unsubscribe = 0x00,
+    Subsctibe = 0x01,
+}
+
+impl TryFrom<u8> for SubscriptionAction {
+    type Error = RdmError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Unsubscribe),
+            0x01 => Ok(Self::Subsctibe),
+            _ => Err(RdmError::InvalidSubscriptionAction(value))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PidSupport(pub u16);
+impl PidSupport {
+    pub fn new() -> Self {
+        Self(0)
+    }
+    
+    pub fn get_supports_get(&self) -> bool {
+        self.0 & 0x01 != 0
+    }
+    pub fn get_supports_set(&self) -> bool {
+        self.0 & 0x02 != 0
+    }
+    pub fn get_supports_packed_sub_get(&self) -> bool {
+        self.0 & 0x04 != 0
+    }
+    pub fn get_supports_packed_sub_set(&self) -> bool {
+        self.0 & 0x08 != 0
+    }
+    pub fn get_supports_packed_idx_get(&self) -> bool {
+        self.0 & 0x10 != 0
+    }
+    pub fn get_supports_packed_idx_set(&self) -> bool {
+        self.0 & 0x20 != 0
+    }
+    pub fn get_supports_non_iddentical_subs(&self) -> bool {
+        self.0 & 0x40 != 0
+    }
+    pub fn get_supports_json_metadata(&self) -> bool {
+        self.0 & 0x80 != 0
+    }
+    pub fn set_supports_get(self, value: bool) -> Self {
+        Self(self.0 & !0x01 | if value {0x01} else {0})
+    }
+    pub fn set_supports_set(self, value: bool) -> Self {
+        Self(self.0 & !0x02 | if value {0x02} else {0})
+    }
+    pub fn set_supports_packed_sub_get(self, value: bool) -> Self {
+        Self(self.0 & !0x04 | if value {0x04} else {0})
+    }
+    pub fn set_supports_packed_sub_set(self, value: bool) -> Self {
+        Self(self.0 & !0x08 | if value {0x08} else {0})
+    }
+    pub fn set_supports_packed_idx_get(self, value: bool) -> Self {
+        Self(self.0 & !0x10 | if value {0x10} else {0})
+    }
+    pub fn set_supports_packed_idx_set(self, value: bool) -> Self {
+        Self(self.0 & !0x20 | if value {0x20} else {0})
+    }
+    pub fn set_supports_non_iddentical_subs(self, value: bool) -> Self {
+        Self(self.0 & !0x40 | if value {0x40} else {0})
+    }
+    pub fn set_supports_json_metadata(self, value: bool) -> Self {
+        Self(self.0 & !0x80 | if value {0x80} else {0})
+    }
+}
+
+impl From<u16> for PidSupport {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+impl From<PidSupport> for u16 {
+    fn from(value: PidSupport) -> Self {
+        value.0
     }
 }
 

--- a/src/rdm/request.rs
+++ b/src/rdm/request.rs
@@ -5,6 +5,7 @@
 //! ```rust
 //! use dmx512_rdm_protocol::rdm::{
 //!     request::{RdmRequest, RequestParameter},
+//!     parameter::ControllerFlags,
 //!     DeviceUID, SubDeviceId,
 //! };
 //!
@@ -13,6 +14,7 @@
 //!     DeviceUID::new(0x0605, 0x04030201),
 //!     0x00,
 //!     0x01,
+//!     ControllerFlags::new(),
 //!     SubDeviceId::RootDevice,
 //!     RequestParameter::GetIdentifyDevice,
 //! )
@@ -43,10 +45,10 @@ use super::{
     bsd_16_crc,
     error::RdmError,
     parameter::{
-        decode_string_bytes, BrokerState, DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode,
-        FadeTimes, IdentifyMode, IdentifyTimeout, Ipv4Address, Ipv4Route, Ipv6Address, LampOnMode, LampState,
-        MergeMode, ParameterId, PinCode, PowerState, PresetPlaybackMode, ResetDeviceMode, SelfTest,
-        StaticConfigType, StatusType, TimeMode,
+        decode_string_bytes, BrokerState, ControllerFlags, DiscoveryState, DisplayInvertMode, EndpointId,
+        EndpointMode, FadeTimes, IdentifyMode, IdentifyTimeout, Ipv4Address, Ipv4Route, Ipv6Address,
+        LampOnMode, LampState, MergeMode, ParameterId, PinCode, PowerState, PresetPlaybackMode,
+        ResetDeviceMode, SelfTest, StaticConfigType, StatusType, SubscriptionAction, TimeMode,
     },
     CommandClass, DeviceUID, EncodedFrame, EncodedParameterData, SubDeviceId, RDM_START_CODE_BYTE,
     RDM_SUB_START_CODE_BYTE,
@@ -82,10 +84,40 @@ pub enum RequestParameter {
     SetSubDeviceIdStatusReportThreshold {
         status_type: StatusType,
     },
+    GetQueuedMessageSensorSubscribe,
+    SetQueuedMessageSensorSubscribe {
+        action: SubscriptionAction,
+        #[cfg(feature = "alloc")]
+        sensors: Vec<u8>,
+        #[cfg(not(feature = "alloc"))]
+        sensors: Vec<u8, 228>,
+    },
     GetSupportedParameters,
     GetParameterDescription {
         parameter_id: u16,
     },
+    GetEnumLabel {
+        parameter_id: ParameterId,
+        enum_index: u32,
+    },
+    GetSupportedParametersEnhanced,
+    GetControllerFlagSupport,
+    GetNackDescription {
+        reason_code: u16,
+    },
+    GetPackedPidSub {
+        pid: ParameterId,
+        index: u16,
+        first_sub_device: u16,
+        sub_device_count: u16,
+    },
+    // SetPackedPidSub, // TODO
+    GetPackedPidIndex {
+        pid: ParameterId,
+        first_item: u16,
+        item_count: u16,
+    },
+    // SetPackedPidIndex, // TODO
     GetDeviceInfo,
     GetProductDetailIdList,
     GetDeviceModelDescription,
@@ -218,6 +250,7 @@ pub enum RequestParameter {
         mode: PresetPlaybackMode,
         level: u8,
     },
+    GetSelfTestEnhanced,
     // E1.37-1
     GetIdentifyMode,
     SetIdentifyMode {
@@ -592,8 +625,15 @@ impl RequestParameter {
             | Self::GetStatusMessages { .. }
             | Self::GetStatusIdDescription { .. }
             | Self::GetSubDeviceIdStatusReportThreshold
+            | Self::GetQueuedMessageSensorSubscribe
             | Self::GetSupportedParameters
             | Self::GetParameterDescription { .. }
+            | Self::GetEnumLabel { .. }
+            | Self::GetSupportedParametersEnhanced
+            | Self::GetControllerFlagSupport
+            | Self::GetNackDescription { .. }
+            | Self::GetPackedPidSub { .. }
+            | Self::GetPackedPidIndex { .. }
             | Self::GetDeviceInfo
             | Self::GetProductDetailIdList
             | Self::GetDeviceModelDescription
@@ -630,6 +670,7 @@ impl RequestParameter {
             | Self::GetPerformSelfTest
             | Self::GetSelfTestDescription { .. }
             | Self::GetPresetPlayback
+            | Self::GetSelfTestEnhanced
             // E1.37-1
             | Self::GetIdentifyMode
             | Self::GetDmxBlockAddress
@@ -711,6 +752,9 @@ impl RequestParameter {
             Self::SetCommsStatus
             | Self::SetClearStatusId
             | Self::SetSubDeviceIdStatusReportThreshold { .. }
+            | Self::SetQueuedMessageSensorSubscribe { .. }
+            // | Self::SetPackedPidSub { .. }
+            // | Self::SetPackedPidIndex { .. }
             | Self::SetDeviceLabel { .. }
             | Self::SetFactoryDefaults
             | Self::SetLanguage { .. }
@@ -810,8 +854,18 @@ impl RequestParameter {
             | Self::SetSubDeviceIdStatusReportThreshold { .. } => {
                 ParameterId::SubDeviceIdStatusReportThreshold
             }
+            Self::GetQueuedMessageSensorSubscribe
+            | Self::SetQueuedMessageSensorSubscribe { .. } => ParameterId::QueuedMessageSensorSubscribe,
             Self::GetSupportedParameters => ParameterId::SupportedParameters,
             Self::GetParameterDescription { .. } => ParameterId::ParameterDescription,
+            Self::GetEnumLabel { .. } => ParameterId::EnumLabel,
+            Self::GetSupportedParametersEnhanced => ParameterId::SupportedParametersEnhanced,
+            Self::GetControllerFlagSupport => ParameterId::ControllerFlagSupport,
+            Self::GetNackDescription { .. } => ParameterId::NackDescription,
+            Self::GetPackedPidSub { .. } => ParameterId::PackedPidSub,
+            // Self::SetPackedPidSub { .. }
+            Self::GetPackedPidIndex { .. } => ParameterId::PackedPidIndex,
+            // Self::SetPackedPidIndex { .. }
             Self::GetDeviceInfo => ParameterId::DeviceInfo,
             Self::GetProductDetailIdList => ParameterId::ProductDetailIdList,
             Self::GetDeviceModelDescription => ParameterId::DeviceModelDescription,
@@ -857,6 +911,7 @@ impl RequestParameter {
             Self::GetSelfTestDescription { .. } => ParameterId::SelfTestDescription,
             Self::SetCapturePreset { .. } => ParameterId::CapturePreset,
             Self::GetPresetPlayback | Self::SetPresetPlayback { .. } => ParameterId::PresetPlayback,
+            Self::GetSelfTestEnhanced => ParameterId::SelfTestEnhanced,
             // E1.37-1
             Self::GetIdentifyMode | Self::SetIdentifyMode { .. } => ParameterId::IdentifyMode,
             Self::GetDmxBlockAddress | Self::SetDmxBlockAddress { .. } => {
@@ -1059,12 +1114,59 @@ impl RequestParameter {
                 #[cfg(not(feature = "alloc"))]
                 buf.push(*status_type as u8).unwrap();
             }
+            Self::GetQueuedMessageSensorSubscribe => {}
+            Self::SetQueuedMessageSensorSubscribe { action, sensors } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1 + sensors.len());
+
+                #[cfg(feature = "alloc")]
+                buf.push(*action as u8);
+                #[cfg(not(feature = "alloc"))]
+                buf.push(*action as u8).unwrap();
+
+                #[cfg(feature = "alloc")]
+                buf.extend(sensors);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(sensors).unwrap();
+            }
             Self::GetSupportedParameters => {}
             Self::GetParameterDescription { parameter_id } => {
                 #[cfg(feature = "alloc")]
                 buf.reserve(0x02);
 
                 buf.extend((*parameter_id).to_be_bytes());
+            }
+            Self::GetEnumLabel { parameter_id, enum_index } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x06);
+
+                buf.extend(u16::from(*parameter_id).to_be_bytes());
+                buf.extend(enum_index.to_be_bytes());
+            }
+            Self::GetSupportedParametersEnhanced => {}
+            Self::GetControllerFlagSupport => {}
+            Self::GetNackDescription { reason_code } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x02);
+
+                buf.extend(u16::from(*reason_code).to_be_bytes());
+            },
+            Self::GetPackedPidSub { pid, index, first_sub_device, sub_device_count } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x08);
+
+                buf.extend(u16::from(*pid).to_be_bytes());
+                buf.extend(index.to_be_bytes());
+                buf.extend(first_sub_device.to_be_bytes());
+                buf.extend(sub_device_count.to_be_bytes());
+            }
+            Self::GetPackedPidIndex { pid, first_item, item_count } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(0x06);
+
+                buf.extend(u16::from(*pid).to_be_bytes());
+                buf.extend(first_item.to_be_bytes());
+                buf.extend(item_count.to_be_bytes());
             }
             Self::GetDeviceInfo => {}
             Self::GetProductDetailIdList => {}
@@ -1370,6 +1472,7 @@ impl RequestParameter {
                 #[cfg(not(feature = "alloc"))]
                 buf.push(*level).unwrap();
             }
+            Self::GetSelfTestEnhanced => {}
             // E1.37-1
             Self::GetIdentifyMode => {}
             Self::SetIdentifyMode { identify_mode } => {
@@ -2181,6 +2284,18 @@ impl RequestParameter {
                     status_type: bytes[0].try_into()?,
                 })
             }
+            (CommandClass::GetCommand, ParameterId::QueuedMessageSensorSubscribe) => Ok(Self::GetQueuedMessageSensorSubscribe),
+            (CommandClass::SetCommand, ParameterId::QueuedMessageSensorSubscribe) => {
+                check_msg_len!(bytes, 1);
+                #[cfg(feature = "alloc")]
+                let sensors = bytes[1..bytes.len().min(1+228)].into();
+                #[cfg(not(feature = "alloc"))]
+                let sensors = Vec::<u8, 228>::from_slice(&bytes[1..bytes.len().min(1+228)]).unwrap();
+                Ok(Self::SetQueuedMessageSensorSubscribe {
+                    action: bytes[0].try_into()?,
+                    sensors 
+                })
+            }
             (CommandClass::GetCommand, ParameterId::SupportedParameters) => {
                 Ok(Self::GetSupportedParameters)
             }
@@ -2188,6 +2303,38 @@ impl RequestParameter {
                 check_msg_len!(bytes, 2);
                 Ok(Self::GetParameterDescription {
                     parameter_id: u16::from_be_bytes([bytes[0], bytes[1]]),
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::EnumLabel) => {
+                check_msg_len!(bytes, 6);
+                Ok(Self::GetEnumLabel {
+                    parameter_id: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    enum_index: u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]])
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::SupportedParametersEnhanced) => Ok(Self::GetSupportedParametersEnhanced),
+            (CommandClass::GetCommand, ParameterId::ControllerFlagSupport) => Ok(Self::GetControllerFlagSupport),
+            (CommandClass::GetCommand, ParameterId::NackDescription) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetNackDescription {
+                    reason_code: u16::from_be_bytes([bytes[0], bytes[1]])
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::PackedPidSub) => {
+                check_msg_len!(bytes, 8);
+                Ok(Self::GetPackedPidSub {
+                    pid: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    index: u16::from_be_bytes([bytes[2], bytes[3]]),
+                    first_sub_device: u16::from_be_bytes([bytes[4], bytes[5]]),
+                    sub_device_count: u16::from_be_bytes([bytes[6], bytes[7]]),
+                })
+            }
+            (CommandClass::GetCommand, ParameterId::PackedPidIndex) => {
+                check_msg_len!(bytes, 6);
+                Ok(Self::GetPackedPidIndex {
+                    pid: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    first_item: u16::from_be_bytes([bytes[2], bytes[3]]),
+                    item_count: u16::from_be_bytes([bytes[4], bytes[5]]),
                 })
             }
             (CommandClass::GetCommand, ParameterId::DeviceInfo) => Ok(Self::GetDeviceInfo),
@@ -2447,6 +2594,7 @@ impl RequestParameter {
                     level: bytes[2],
                 })
             }
+            (CommandClass::GetCommand, ParameterId::SelfTestEnhanced) => Ok(Self::GetSelfTestEnhanced),
             // E1.37-1
             (CommandClass::GetCommand, ParameterId::IdentifyMode) => Ok(Self::GetIdentifyMode),
             (CommandClass::SetCommand, ParameterId::IdentifyMode) => {
@@ -3038,6 +3186,7 @@ pub struct RdmRequest {
     pub source_uid: DeviceUID,
     pub transaction_number: u8,
     pub port_id: u8,
+    pub controller_flags: ControllerFlags,
     pub sub_device_id: SubDeviceId,
     pub parameter: RequestParameter,
 }
@@ -3048,6 +3197,7 @@ impl RdmRequest {
         source_uid: DeviceUID,
         transaction_number: u8,
         port_id: u8,
+        controller_flags: ControllerFlags,
         sub_device_id: SubDeviceId,
         parameter: RequestParameter,
     ) -> Self {
@@ -3056,6 +3206,7 @@ impl RdmRequest {
             source_uid,
             transaction_number,
             port_id,
+            controller_flags,
             sub_device_id,
             parameter,
         }
@@ -3109,11 +3260,10 @@ impl RdmRequest {
         #[cfg(not(feature = "alloc"))]
         buf.push(self.port_id).unwrap();
 
-        // Message Count shall be set to 0x00 in all controller generated requests
         #[cfg(feature = "alloc")]
-        buf.push(0x00);
+        buf.push(self.controller_flags.0);
         #[cfg(not(feature = "alloc"))]
-        buf.push(0x00).unwrap();
+        buf.push(self.controller_flags.0).unwrap();
 
         buf.extend(u16::from(self.sub_device_id).to_be_bytes());
 
@@ -3145,6 +3295,7 @@ impl RdmRequest {
 
         let transaction_number = bytes[15];
         let port_id = bytes[16];
+        let controller_flags = bytes[17].into();
         let sub_device_id = u16::from_be_bytes([bytes[18], bytes[19]]).into();
         let command_class = bytes[20].try_into()?;
         let parameter_id = u16::from_be_bytes([bytes[21], bytes[22]]).into();
@@ -3163,6 +3314,7 @@ impl RdmRequest {
             source_uid,
             transaction_number,
             port_id,
+            controller_flags,
             sub_device_id,
             parameter,
         ))
@@ -3194,6 +3346,7 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
             SubDeviceId::Id(0x01),
             RequestParameter::DiscUniqueBranch {
                 lower_bound_uid: DeviceUID::new(0x0000, 0x00000000),
@@ -3249,6 +3402,8 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
+
             SubDeviceId::Id(0x01),
             RequestParameter::DiscUniqueBranch {
                 lower_bound_uid: DeviceUID::new(0x0000, 0x00000000),
@@ -3266,6 +3421,7 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
             SubDeviceId::RootDevice,
             RequestParameter::GetIdentifyDevice,
         )
@@ -3314,6 +3470,7 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
             SubDeviceId::RootDevice,
             RequestParameter::GetIdentifyDevice,
         );
@@ -3328,6 +3485,7 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
             SubDeviceId::RootDevice,
             RequestParameter::ManufacturerSpecific {
                 command_class: CommandClass::SetCommand,
@@ -3385,6 +3543,7 @@ mod tests {
             DeviceUID::new(0x0605, 0x04030201),
             0x00,
             0x01,
+            ControllerFlags::new(),
             SubDeviceId::RootDevice,
             RequestParameter::ManufacturerSpecific {
                 command_class: CommandClass::SetCommand,

--- a/src/rdm/request.rs
+++ b/src/rdm/request.rs
@@ -111,13 +111,26 @@ pub enum RequestParameter {
         first_sub_device: u16,
         sub_device_count: u16,
     },
-    // SetPackedPidSub, // TODO
+    SetPackedPidSub {
+        pid: ParameterId,
+        index: u16,
+        #[cfg(feature = "alloc")]
+        packed_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))]
+        packed_data: Vec<u8, 227>,
+    },
     GetPackedPidIndex {
         pid: ParameterId,
         first_item: u16,
         item_count: u16,
     },
-    // SetPackedPidIndex, // TODO
+    SetPackedPidIndex {
+        pid: ParameterId,
+        #[cfg(feature = "alloc")]
+        packed_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))]
+        packed_data: Vec<u8, 229>,
+    },
     GetDeviceInfo,
     GetProductDetailIdList,
     GetDeviceModelDescription,
@@ -753,8 +766,8 @@ impl RequestParameter {
             | Self::SetClearStatusId
             | Self::SetSubDeviceIdStatusReportThreshold { .. }
             | Self::SetQueuedMessageSensorSubscribe { .. }
-            // | Self::SetPackedPidSub { .. }
-            // | Self::SetPackedPidIndex { .. }
+            | Self::SetPackedPidSub { .. }
+            | Self::SetPackedPidIndex { .. }
             | Self::SetDeviceLabel { .. }
             | Self::SetFactoryDefaults
             | Self::SetLanguage { .. }
@@ -862,10 +875,10 @@ impl RequestParameter {
             Self::GetSupportedParametersEnhanced => ParameterId::SupportedParametersEnhanced,
             Self::GetControllerFlagSupport => ParameterId::ControllerFlagSupport,
             Self::GetNackDescription { .. } => ParameterId::NackDescription,
-            Self::GetPackedPidSub { .. } => ParameterId::PackedPidSub,
-            // Self::SetPackedPidSub { .. }
-            Self::GetPackedPidIndex { .. } => ParameterId::PackedPidIndex,
-            // Self::SetPackedPidIndex { .. }
+            Self::GetPackedPidSub { .. } |
+            Self::SetPackedPidSub { .. } => ParameterId::PackedPidSub,
+            Self::GetPackedPidIndex { .. } |
+            Self::SetPackedPidIndex { .. } => ParameterId::PackedPidIndex,
             Self::GetDeviceInfo => ParameterId::DeviceInfo,
             Self::GetProductDetailIdList => ParameterId::ProductDetailIdList,
             Self::GetDeviceModelDescription => ParameterId::DeviceModelDescription,
@@ -1160,6 +1173,17 @@ impl RequestParameter {
                 buf.extend(first_sub_device.to_be_bytes());
                 buf.extend(sub_device_count.to_be_bytes());
             }
+            Self::SetPackedPidSub { pid, index, packed_data } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(4 + packed_data.len());
+
+                buf.extend(u16::from(*pid).to_be_bytes());
+                buf.extend(index.to_be_bytes());
+                #[cfg(feature = "alloc")]
+                buf.extend_from_slice(packed_data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(packed_data).unwrap();
+            }
             Self::GetPackedPidIndex { pid, first_item, item_count } => {
                 #[cfg(feature = "alloc")]
                 buf.reserve(0x06);
@@ -1167,6 +1191,16 @@ impl RequestParameter {
                 buf.extend(u16::from(*pid).to_be_bytes());
                 buf.extend(first_item.to_be_bytes());
                 buf.extend(item_count.to_be_bytes());
+            }
+            Self::SetPackedPidIndex { pid, packed_data } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(2 + packed_data.len());
+
+                buf.extend(u16::from(*pid).to_be_bytes());
+                #[cfg(feature = "alloc")]
+                buf.extend_from_slice(packed_data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(packed_data).unwrap();
             }
             Self::GetDeviceInfo => {}
             Self::GetProductDetailIdList => {}
@@ -2329,12 +2363,33 @@ impl RequestParameter {
                     sub_device_count: u16::from_be_bytes([bytes[6], bytes[7]]),
                 })
             }
+            (CommandClass::SetCommand, ParameterId::PackedPidSub) => {
+                check_msg_len!(bytes, 4);
+                Ok(Self::SetPackedPidSub {
+                    pid: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    index: u16::from_be_bytes([bytes[2], bytes[3]]),
+                    #[cfg(feature = "alloc")]
+                    packed_data: bytes[4..].to_vec(),
+                    #[cfg(not(feature = "alloc"))]
+                    packed_data: Vec::<u8, 227>::from_slice(&bytes[4..]).unwrap(),
+                })
+            }
             (CommandClass::GetCommand, ParameterId::PackedPidIndex) => {
                 check_msg_len!(bytes, 6);
                 Ok(Self::GetPackedPidIndex {
                     pid: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
                     first_item: u16::from_be_bytes([bytes[2], bytes[3]]),
                     item_count: u16::from_be_bytes([bytes[4], bytes[5]]),
+                })
+            }
+            (CommandClass::SetCommand, ParameterId::PackedPidIndex) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::SetPackedPidIndex {
+                    pid: u16::from_be_bytes([bytes[0], bytes[1]]).into(),
+                    #[cfg(feature = "alloc")]
+                    packed_data: bytes[2..].to_vec(),
+                    #[cfg(not(feature = "alloc"))]
+                    packed_data: Vec::<u8, 229>::from_slice(&bytes[2..]).unwrap(),
                 })
             }
             (CommandClass::GetCommand, ParameterId::DeviceInfo) => Ok(Self::GetDeviceInfo),

--- a/src/rdm/response.rs
+++ b/src/rdm/response.rs
@@ -48,12 +48,12 @@
 use super::{
     bsd_16_crc,
     parameter::{
-        decode_string_bytes, BrokerState, DefaultSlotValue, DeviceInfo, DhcpMode, DiscoveryCountStatus,
-        DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode, EndpointType, IdentifyMode, IdentifyTimeout,
-        Ipv4Address, Ipv4Route, Ipv6Address, LampOnMode, LampState, MergeMode, NetworkInterface,
-        ParameterDescription, ParameterId, PinCode, PowerState, PresetPlaybackMode,
-        PresetProgrammed, ProductDetail, SelfTest, SensorDefinition, SensorType, SensorUnit,
-        SensorValue, ShippingLockState, SlotInfo, StaticConfigType, StatusMessage, StatusType,
+        decode_string_bytes, BrokerState, ControllerFlags, DefaultSlotValue, DeviceInfo, DhcpMode, DiscoveryCountStatus,
+        DiscoveryState, DisplayInvertMode, EndpointId, EndpointMode, EndpointType, IdentifyMode, IdentifyTimeout, Ipv4Address,
+        Ipv4Route, Ipv6Address, LampOnMode, LampState, MergeMode, NetworkInterface,
+        ParameterDescription, ParameterId, PidSupport, PinCode, PowerState, PresetPlaybackMode,
+        PresetProgrammed, ProductDetail, SelfTest, SelfTestCapability, SelfTestStatus,
+        SensorDefinition, SensorType, SensorUnit, SensorValue, ShippingLockState, SlotInfo, StaticConfigType, StatusMessage, StatusType,
         SupportedTimes, TimeMode,
     },
     CommandClass, DeviceUID, EncodedFrame, EncodedParameterData, RdmError, SubDeviceId,
@@ -69,21 +69,34 @@ use heapless::{String, Vec};
 // E1.20 2025 Table A-17
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ResponseNackReasonCode {
-    UnknownPid = 0x0000,
-    FormatError = 0x0001,
-    HardwareFault = 0x0002,
-    ProxyReject = 0x0003,
-    WriteProtect = 0x0004,
-    UnsupportedCommandClass = 0x0005,
-    DataOutOfRange = 0x0006,
-    BufferFull = 0x0007,
-    PacketSizeUnsupported = 0x0008,
-    SubDeviceIdOutOfRange = 0x0009,
-    ProxyBufferFull = 0x000a,
-    ActionNotSupported = 0x000b,
-    EndpointNumberInvalid = 0x000c,
-    InvalidEndpointMode = 0x000d,
-    UnknownUid = 0x000e,
+    UnknownPid,
+    FormatError,
+    HardwareFault,
+    ProxyReject,
+    WriteProtect,
+    UnsupportedCommandClass,
+    DataOutOfRange,
+    BufferFull,
+    PacketSizeUnsupported,
+    SubDeviceIdOutOfRange,
+    ProxyBufferFull,
+    ActionNotSupported,
+    EndpointNumberInvalid,
+    InvalidEndpointMode,
+    UnknownUid,
+    UnknownScope,
+    InvalidStaticConfigType,
+    InvalidIpv4Address,
+    InvalidIpv6Address,
+    InvalidPort,
+    DeviceAbsent,
+    SensorOutOfRange,
+    SensorFault,
+    PackingNotSupported,
+    ErrorInPackedListTransaction,
+    ProxyDrop,
+    AllCallSetFail,
+    ManufacturerSpecific(u16),
 }
 
 impl TryFrom<u16> for ResponseNackReasonCode {
@@ -106,7 +119,55 @@ impl TryFrom<u16> for ResponseNackReasonCode {
             0x000c => Ok(Self::EndpointNumberInvalid),
             0x000d => Ok(Self::InvalidEndpointMode),
             0x000e => Ok(Self::UnknownUid),
+            0x000f => Ok(Self::UnknownScope),
+            0x0010 => Ok(Self::InvalidStaticConfigType),
+            0x0011 => Ok(Self::InvalidIpv4Address),
+            0x0012 => Ok(Self::InvalidIpv6Address),
+            0x0013 => Ok(Self::InvalidPort),
+            0x0014 => Ok(Self::DeviceAbsent),
+            0x0015 => Ok(Self::SensorOutOfRange),
+            0x0016 => Ok(Self::SensorFault),
+            0x0017 => Ok(Self::PackingNotSupported),
+            0x0018 => Ok(Self::ErrorInPackedListTransaction),
+            0x0019 => Ok(Self::ProxyDrop),
+            0x0020 => Ok(Self::AllCallSetFail),
+            n if n&0x8000 != 0 => Ok(Self::ManufacturerSpecific(n)),
             value => Err(RdmError::InvalidNackReasonCode(value)),
+        }
+    }
+}
+
+impl From<ResponseNackReasonCode> for u16 {
+    fn from(value: ResponseNackReasonCode) -> Self {
+        match value {
+            ResponseNackReasonCode::UnknownPid => 0x0000,
+            ResponseNackReasonCode::FormatError => 0x0001,
+            ResponseNackReasonCode::HardwareFault => 0x0002,
+            ResponseNackReasonCode::ProxyReject => 0x0003,
+            ResponseNackReasonCode::WriteProtect => 0x0004,
+            ResponseNackReasonCode::UnsupportedCommandClass => 0x0005,
+            ResponseNackReasonCode::DataOutOfRange => 0x0006,
+            ResponseNackReasonCode::BufferFull => 0x0007,
+            ResponseNackReasonCode::PacketSizeUnsupported => 0x0008,
+            ResponseNackReasonCode::SubDeviceIdOutOfRange => 0x0009,
+            ResponseNackReasonCode::ProxyBufferFull => 0x000a,
+            ResponseNackReasonCode::ActionNotSupported => 0x000b,
+            ResponseNackReasonCode::EndpointNumberInvalid => 0x000c,
+            ResponseNackReasonCode::InvalidEndpointMode => 0x000d,
+            ResponseNackReasonCode::UnknownUid => 0x000e,
+            ResponseNackReasonCode::UnknownScope => 0x000f,
+            ResponseNackReasonCode::InvalidStaticConfigType => 0x0010,
+            ResponseNackReasonCode::InvalidIpv4Address => 0x0011,
+            ResponseNackReasonCode::InvalidIpv6Address => 0x0012,
+            ResponseNackReasonCode::InvalidPort => 0x0013,
+            ResponseNackReasonCode::DeviceAbsent => 0x0014,
+            ResponseNackReasonCode::SensorOutOfRange => 0x0015,
+            ResponseNackReasonCode::SensorFault => 0x0016,
+            ResponseNackReasonCode::PackingNotSupported => 0x0017,
+            ResponseNackReasonCode::ErrorInPackedListTransaction => 0x0018,
+            ResponseNackReasonCode::ProxyDrop => 0x0019,
+            ResponseNackReasonCode::AllCallSetFail => 0x0020,
+            ResponseNackReasonCode::ManufacturerSpecific(value) => value,
         }
     }
 }
@@ -129,6 +190,19 @@ impl Display for ResponseNackReasonCode {
             Self::EndpointNumberInvalid => "The Endpoint Number is invalid.",
             Self::InvalidEndpointMode => "The Endpoint Mode is invalid.",
             Self::UnknownUid => "The UID is not known to the responder.",
+            Self::UnknownScope => "The Component is not participating in the given Scope.",
+            Self::InvalidStaticConfigType => "The Static Config Type is invalid.",
+            Self::InvalidIpv4Address => "The IPv4 Address is invalid.",
+            Self::InvalidIpv6Address => "The IPv6 Address is invalid.",
+            Self::InvalidPort => "The transport layer port is invalid.",
+            Self::DeviceAbsent => "The addressed sub-device or sensor is absent.",
+            Self::SensorOutOfRange => "The addressed sensor is out of range.",
+            Self::SensorFault => "The sensor is faulty.",
+            Self::PackingNotSupported => "The specified PID is not supported in packed messages.",
+            Self::ErrorInPackedListTransaction => "Error attempting to action an item in a packed list.",
+            Self::ProxyDrop => "The response to the proxy was lost.",
+            Self::AllCallSetFail => "A SET to SUB_DEVICE_ALL_CALL failed.",
+            Self::ManufacturerSpecific(_) => "Manufacturer specific NACK Code",
         };
 
         f.write_str(message)
@@ -142,6 +216,7 @@ pub enum ResponseType {
     AckTimer = 0x01,
     NackReason = 0x02,
     AckOverflow = 0x03,
+    AckTimerHiRes = 0x04,
 }
 
 impl TryFrom<u8> for ResponseType {
@@ -153,6 +228,7 @@ impl TryFrom<u8> for ResponseType {
             0x01 => Ok(Self::AckTimer),
             0x02 => Ok(Self::NackReason),
             0x03 => Ok(Self::AckOverflow),
+            0x04 => Ok(Self::AckTimerHiRes),
             _ => Err(RdmError::InvalidResponseType(value)),
         }
     }
@@ -164,6 +240,8 @@ pub enum ResponseData {
     ParameterData(Option<ResponseParameterData>),
     /// Estimated response time in 10ths of a second (100ms)
     EstimateResponseTime(u16),
+    /// Estimated response time in milliseconds
+    EstimateResponseTimeHiRes(u16),
     NackReason(ResponseNackReasonCode),
 }
 
@@ -185,7 +263,8 @@ impl ResponseData {
                 buf.extend(data);
             }
             Self::ParameterData(None) => {}
-            Self::EstimateResponseTime(time) => {
+            Self::EstimateResponseTime(time) |
+            Self::EstimateResponseTimeHiRes(time) => {
                 #[cfg(feature = "alloc")]
                 buf.reserve(2);
 
@@ -195,7 +274,7 @@ impl ResponseData {
                 #[cfg(feature = "alloc")]
                 buf.reserve(2);
 
-                buf.extend((*reason as u16).to_be_bytes());
+                buf.extend(u16::from(*reason).to_be_bytes());
             }
         }
 
@@ -224,11 +303,19 @@ impl ResponseData {
                 Ok(ResponseData::ParameterData(parameter_data))
             }
             ResponseType::AckTimer => {
+                check_msg_len!(bytes, 2);
                 let estimated_response_time = u16::from_be_bytes(bytes[0..=1].try_into()?);
 
                 Ok(ResponseData::EstimateResponseTime(estimated_response_time))
             }
+            ResponseType::AckTimerHiRes => {
+                check_msg_len!(bytes, 2);
+                let estimated_response_time = u16::from_be_bytes(bytes[0..=1].try_into()?);
+
+                Ok(ResponseData::EstimateResponseTimeHiRes(estimated_response_time))
+            }
             ResponseType::NackReason => {
+                check_msg_len!(bytes, 2);
                 let nack_reason = u16::from_be_bytes(bytes[0..=1].try_into()?).try_into()?;
 
                 Ok(ResponseData::NackReason(nack_reason))
@@ -272,11 +359,38 @@ pub enum ResponseParameterData {
         #[cfg(not(feature = "alloc"))] String<32>,
     ),
     GetSubDeviceIdStatusReportThreshold(StatusType),
+    GetQueuedMessageSensorSubscribe(
+        #[cfg(feature = "alloc")] Vec<u8>,
+        #[cfg(not(feature = "alloc"))] Vec<u8, 228>,
+    ),
     GetSupportedParameters(
         #[cfg(feature = "alloc")] Vec<u16>,
         #[cfg(not(feature = "alloc"))] Vec<u16, 115>,
     ),
     GetParameterDescription(ParameterDescription),
+    GetEnumLabel {
+        pid_requested: u16,
+        enum_index: u32,
+        max_enum_index: u32,
+        #[cfg(feature = "alloc")]
+        label: String,
+        #[cfg(not(feature = "alloc"))]
+        label: String<32>,
+    },
+    GetSupportedParametersEnhanced(
+        #[cfg(feature = "alloc")] Vec<(ParameterId, PidSupport)>,
+        #[cfg(not(feature = "alloc"))] Vec<(ParameterId, PidSupport), 57>,
+    ),
+    GetControllerFlagSupport(ControllerFlags),
+    GetNackDescription {
+        nack_reason_code: ResponseNackReasonCode,
+        #[cfg(feature = "alloc")]
+        description: String,
+        #[cfg(not(feature = "alloc"))]
+        description: String<32>,
+    },
+    // GetPackedPidSub // TODO
+    // GetPackedPidIndex // TODO
     GetDeviceInfo(DeviceInfo),
     GetProductDetailIdList(
         #[cfg(feature = "alloc")] Vec<ProductDetail>,
@@ -375,6 +489,13 @@ pub enum ResponseParameterData {
     GetPresetPlayback {
         mode: PresetPlaybackMode,
         level: u8,
+    },
+    GetSelfTestEnhanced {
+        result_code_enum: Option<ParameterId>,
+        #[cfg(feature = "alloc")]
+        tests: Vec<(SelfTest, SelfTestStatus, SelfTestCapability, u16)>,
+        #[cfg(not(feature = "alloc"))]
+        tests: Vec<(SelfTest, SelfTestStatus, SelfTestCapability, u16), 38>,
     },
     // E1.37-1
     GetIdentifyMode(IdentifyMode),
@@ -535,7 +656,7 @@ pub enum ResponseParameterData {
     ),
     GetDnsDomainName(
         #[cfg(feature = "alloc")] String,
-        #[cfg(not(feature = "alloc"))] String<231>,
+        #[cfg(not(feature = "alloc"))] String<32>,
     ),
     // E1.37-5
     GetIdentifyTimeout(IdentifyTimeout),
@@ -878,6 +999,15 @@ impl ResponseParameterData {
                 #[cfg(not(feature = "alloc"))]
                 buf.push(*status as u8).unwrap();
             }
+            Self::GetQueuedMessageSensorSubscribe(subs) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.extend(subs);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(subs).unwrap();
+            }
             Self::GetSupportedParameters(parameters) => {
                 #[cfg(feature = "alloc")]
                 buf.reserve(parameters.len() * 2);
@@ -930,6 +1060,49 @@ impl ResponseParameterData {
                 buf.extend(description.description.bytes());
                 #[cfg(not(feature = "alloc"))]
                 buf.extend(description.description.bytes());
+            }
+            Self::GetEnumLabel {
+                pid_requested,
+                enum_index,
+                max_enum_index,
+                label
+            } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(10+label.len());
+
+                buf.extend(pid_requested.to_be_bytes());
+                buf.extend(enum_index.to_be_bytes());
+                buf.extend(max_enum_index.to_be_bytes());
+
+                buf.extend(label.bytes());
+            }
+            Self::GetSupportedParametersEnhanced(params) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(params.len()*4);
+
+                for (pid, sup) in params {
+                    buf.extend(u16::from(*pid).to_be_bytes());
+                    buf.extend(u16::from(*sup).to_be_bytes());
+                }
+            }
+            Self::GetControllerFlagSupport(flags) => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(1);
+
+                #[cfg(feature = "alloc")]
+                buf.push((*flags).into());
+                #[cfg(not(feature = "alloc"))]
+                buf.push((*flags).into()).unwrap();
+            }
+            Self::GetNackDescription {
+                nack_reason_code,
+                description
+            } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(2+description.len());
+
+                buf.extend(u16::from(*nack_reason_code).to_be_bytes());
+                buf.extend(description.bytes());
             }
             Self::GetDeviceInfo(info) => {
                 info.encode(&mut buf);
@@ -1083,6 +1256,11 @@ impl ResponseParameterData {
                 buf.reserve(14 + definition.description.len());
 
                 #[cfg(feature = "alloc")]
+                buf.push(definition.id.into());
+                #[cfg(not(feature = "alloc"))]
+                buf.push(definition.id.into()).unwrap();
+
+                #[cfg(feature = "alloc")]
                 buf.push(definition.kind.into());
                 #[cfg(not(feature = "alloc"))]
                 buf.push(definition.kind.into()).unwrap();
@@ -1097,27 +1275,23 @@ impl ResponseParameterData {
                 #[cfg(not(feature = "alloc"))]
                 buf.push(definition.prefix as u8).unwrap();
 
-                #[cfg(feature = "alloc")]
-                buf.push(definition.prefix as u8);
-                #[cfg(not(feature = "alloc"))]
-                buf.push(definition.prefix as u8).unwrap();
-
                 buf.extend(definition.range_minimum_value.to_be_bytes());
                 buf.extend(definition.range_maximum_value.to_be_bytes());
                 buf.extend(definition.normal_minimum_value.to_be_bytes());
                 buf.extend(definition.normal_maximum_value.to_be_bytes());
 
-                #[cfg(feature = "alloc")]
-                buf.push(definition.is_lowest_highest_detected_value_supported as u8);
-                #[cfg(not(feature = "alloc"))]
-                buf.push(definition.is_lowest_highest_detected_value_supported as u8)
-                    .unwrap();
+                let mut flags = 0;
+                if definition.is_recorded_value_supported {
+                    flags |= 0x01;
+                }
+                if definition.is_lowest_highest_detected_value_supported {
+                    flags |= 0x02;
+                }
 
                 #[cfg(feature = "alloc")]
-                buf.push(definition.is_recorded_value_supported as u8);
+                buf.push(flags);
                 #[cfg(not(feature = "alloc"))]
-                buf.push(definition.is_recorded_value_supported as u8)
-                    .unwrap();
+                buf.push(flags).unwrap();
 
                 buf.extend(definition.description.bytes());
             }
@@ -1325,6 +1499,32 @@ impl ResponseParameterData {
                 buf.push(*level);
                 #[cfg(not(feature = "alloc"))]
                 buf.push(*level).unwrap();
+            }
+            Self::GetSelfTestEnhanced { result_code_enum, tests } => {
+                if let Some(rc) = *result_code_enum {
+                    #[cfg(feature = "alloc")]
+                    buf.reserve(2+tests.len()*6);
+
+                    buf.extend(u16::from(rc).to_be_bytes());
+                } else {
+                    #[cfg(feature = "alloc")]
+                    buf.reserve(2+tests.len()*6);
+                }
+
+                for (tst, stat, capa, res) in tests {
+                    #[cfg(feature = "alloc")]
+                    buf.push((*tst).into());
+                    #[cfg(not(feature = "alloc"))]
+                    buf.push((*tst).into()).unwrap();
+
+                    #[cfg(feature = "alloc")]
+                    buf.push(*stat as u8);
+                    #[cfg(not(feature = "alloc"))]
+                    buf.push(*stat as u8).unwrap();
+
+                    buf.extend(u16::from(*capa).to_be_bytes());
+                    buf.extend(u16::from(*res).to_be_bytes());
+                }
             }
             Self::GetIdentifyMode(identify_mode) => {
                 #[cfg(feature = "alloc")]
@@ -2451,6 +2651,13 @@ impl ResponseParameterData {
                     bytes[0].try_into()?,
                 ))
             }
+            (CommandClass::GetCommandResponse, ParameterId::QueuedMessageSensorSubscribe) => {
+                #[cfg(feature = "alloc")]
+                let sensors = bytes[..bytes.len().min(228)].into();
+                #[cfg(not(feature = "alloc"))]
+                let sensors = Vec::<u8, 228>::from_slice(&bytes[..bytes.len().min(228)]).unwrap();
+                Ok(Self::GetQueuedMessageSensorSubscribe(sensors))
+            }
             (CommandClass::GetCommandResponse, ParameterId::SupportedParameters) => {
                 let parameters = bytes
                     .chunks(2)
@@ -2478,6 +2685,42 @@ impl ResponseParameterData {
                     raw_default_value: bytes[16..=19].try_into()?,
                     description: decode_string_bytes(&bytes[20..bytes.len().min(20+32)])?,
                 }))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::EnumLabel) => {
+                check_msg_len!(bytes, 10);
+                Ok(Self::GetEnumLabel {
+                    pid_requested: u16::from_be_bytes([bytes[0], bytes[1]]),
+                    enum_index: u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]),
+                    max_enum_index: u32::from_be_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]),
+                    label: decode_string_bytes(&bytes[10..bytes.len().min(10+32)])?,
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::SupportedParametersEnhanced) => {
+                let pids = bytes
+                    .chunks_exact(4)
+                    .map(|chunk| {
+                        (
+                            u16::from_be_bytes([chunk[0], chunk[1]]).into(),
+                            u16::from_be_bytes([chunk[2], chunk[3]]).into(),
+                        )
+                    });
+                Ok(Self::GetSupportedParametersEnhanced(
+                    #[cfg(feature = "alloc")]
+                    pids.collect::<Vec<(ParameterId, PidSupport)>>(),
+                    #[cfg(not(feature = "alloc"))]
+                    pids.collect::<Vec<(ParameterId, PidSupport), 57>>(),
+                ))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::ControllerFlagSupport) => {
+                check_msg_len!(bytes, 1);
+                Ok(Self::GetControllerFlagSupport(bytes[0].into()))
+            }
+            (CommandClass::GetCommandResponse, ParameterId::NackDescription) => {
+                check_msg_len!(bytes, 2);
+                Ok(Self::GetNackDescription {
+                    nack_reason_code: u16::from_be_bytes([bytes[0], bytes[1]]).try_into()?,
+                    description: decode_string_bytes(&bytes[2..bytes.len().min(2+32)])?,
+                })
             }
             (CommandClass::GetCommandResponse, ParameterId::DeviceInfo) => {
                 check_msg_len!(bytes, 19);
@@ -2749,6 +2992,30 @@ impl ResponseParameterData {
                     mode: u16::from_be_bytes(bytes[0..=1].try_into()?).into(),
                     level: bytes[2],
                 })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::SelfTestEnhanced) => {
+                let (result_code_enum, off) = if bytes.len() % 6 == 2 {
+                    (Some(u16::from_be_bytes([bytes[0], bytes[1]]).into()), 2)
+                } else {
+                    (None, 0)
+                };
+                let tests = bytes[off..]
+                    .chunks_exact(6)
+                    .map(|chunk| {
+                        Ok((
+                            chunk[0].into(),
+                            chunk[1].try_into()?,
+                            u16::from_be_bytes([chunk[2], chunk[3]]).into(),
+                            u16::from_be_bytes([chunk[4], chunk[5]]).into(),
+                        ))
+                    });
+                Ok(Self::GetSelfTestEnhanced {
+                    result_code_enum,
+                    #[cfg(feature = "alloc")]
+                    tests: tests.collect::<Result<Vec<(SelfTest, SelfTestStatus, SelfTestCapability, u16)>, RdmError>>()?,
+                    #[cfg(not(feature = "alloc"))]
+                    tests: tests.collect::<Result<Vec<(SelfTest, SelfTestStatus, SelfTestCapability, u16), 38>, RdmError>>()?,
+            })
             }
             // E1.37-1
             (CommandClass::GetCommandResponse, ParameterId::IdentifyMode) => {
@@ -3104,7 +3371,10 @@ impl ResponseParameterData {
                     if len != 0 {
                         // limit string length to 32 bytes, truncate if longer
                         let tag = decode_string_bytes(&remaining[..len.min(32)])?;
+                        #[cfg(feature = "alloc")]
                         tags.push(tag);
+                        #[cfg(not(feature = "alloc"))]
+                        tags.push(tag).unwrap();
                     }
                     remaining = &remaining[(len+1).min(remaining.len())..];
                 }

--- a/src/rdm/response.rs
+++ b/src/rdm/response.rs
@@ -389,8 +389,22 @@ pub enum ResponseParameterData {
         #[cfg(not(feature = "alloc"))]
         description: String<32>,
     },
-    // GetPackedPidSub // TODO
-    // GetPackedPidIndex // TODO
+    GetPackedPidSub {
+        /// If this is the first message it will contain the 2-byte PID and the 2-byte index,
+        /// followed by the packed data items
+        /// 
+        /// Otherwise it will just contain the packed data items
+        #[cfg(feature = "alloc")] packed_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))] packed_data: Vec<u8, 231>,
+    },
+    GetPackedPidIndex {
+        /// If this is the first message it will contain the 2-byte PID,
+        /// followed by the packed data items
+        /// 
+        /// Otherwise it will just contain the packed data items
+        #[cfg(feature = "alloc")] packed_data: Vec<u8>,
+        #[cfg(not(feature = "alloc"))] packed_data: Vec<u8, 231>,
+    },
     GetDeviceInfo(DeviceInfo),
     GetProductDetailIdList(
         #[cfg(feature = "alloc")] Vec<ProductDetail>,
@@ -1103,6 +1117,16 @@ impl ResponseParameterData {
 
                 buf.extend(u16::from(*nack_reason_code).to_be_bytes());
                 buf.extend(description.bytes());
+            }
+            Self::GetPackedPidSub { packed_data } |
+            Self::GetPackedPidIndex { packed_data } => {
+                #[cfg(feature = "alloc")]
+                buf.reserve(packed_data.len());
+
+                #[cfg(feature = "alloc")]
+                buf.extend_from_slice(packed_data);
+                #[cfg(not(feature = "alloc"))]
+                buf.extend_from_slice(packed_data).unwrap();
             }
             Self::GetDeviceInfo(info) => {
                 info.encode(&mut buf);
@@ -2720,6 +2744,22 @@ impl ResponseParameterData {
                 Ok(Self::GetNackDescription {
                     nack_reason_code: u16::from_be_bytes([bytes[0], bytes[1]]).try_into()?,
                     description: decode_string_bytes(&bytes[2..bytes.len().min(2+32)])?,
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::PackedPidSub) => {
+                Ok(Self::GetPackedPidSub {
+                    #[cfg(feature = "alloc")]
+                    packed_data: bytes.to_vec(),
+                    #[cfg(not(feature = "alloc"))]
+                    packed_data: Vec::<u8, 231>::from_slice(bytes).unwrap(),
+                })
+            }
+            (CommandClass::GetCommandResponse, ParameterId::PackedPidIndex) => {
+                Ok(Self::GetPackedPidIndex {
+                    #[cfg(feature = "alloc")]
+                    packed_data: bytes.to_vec(),
+                    #[cfg(not(feature = "alloc"))]
+                    packed_data: Vec::<u8, 231>::from_slice(bytes).unwrap(),
                 })
             }
             (CommandClass::GetCommandResponse, ParameterId::DeviceInfo) => {

--- a/src/rdm/utils.rs
+++ b/src/rdm/utils.rs
@@ -1,4 +1,7 @@
 
+#[cfg(not(feature = "alloc"))]
+use heapless::Vec;
+
 #[macro_export]
 macro_rules! check_msg_len {
     ($msg:ident, $min_len:literal) => {
@@ -6,4 +9,162 @@ macro_rules! check_msg_len {
             return Err(RdmError::InvalidMessageLength($msg.len() as u8));
         }
     };
+}
+
+pub struct PackedEntryIterator<'a> {
+    pos: usize,
+    data: &'a [u8],
+}
+impl<'a> PackedEntryIterator<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self {
+            pos: 0,
+            data
+        }
+    }
+}
+impl<'a> Iterator for PackedEntryIterator<'a> {
+    type Item = Result<(u16, &'a [u8]), ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.data.len() {
+            return None;
+        }
+        let data = &self.data[self.pos..];
+
+        if data.len() < 3 {
+            self.pos = self.data.len();
+            return Some(Err(()));
+        }
+        let ident = u16::from_be_bytes([data[0], data[1]]);
+        let len = data[2] as usize;
+
+        self.pos += 3;
+        let data = &data[3..];
+
+        if data.len() < len {
+            self.pos = self.data.len();
+            return Some(Err(()));
+        }
+
+        let item_data = &data[..len];
+        self.pos += len;
+
+        Some(Ok((
+            ident,
+            item_data
+        )))
+    }
+}
+
+#[cfg(feature = "alloc")]
+type T = Vec<u8>;
+#[cfg(not(feature = "alloc"))]
+type T = Vec<u8, 231>;
+
+pub fn write_packed_entry(buf: &mut T, ident: u16, data: &[u8]) -> bool {
+    if data.len() > 255 {
+        return false;
+    }
+
+    buf.extend(ident.to_be_bytes());
+
+    #[cfg(feature = "alloc")]
+    buf.push(data.len() as u8);
+    #[cfg(not(feature = "alloc"))]
+    buf.push(data.len() as u8).unwrap();
+
+    #[cfg(feature = "alloc")]
+    buf.extend_from_slice(data);
+    #[cfg(not(feature = "alloc"))]
+    buf.extend_from_slice(data).unwrap();
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rdm::utils::{PackedEntryIterator, write_packed_entry};
+
+
+    // Test 1: DMX Start address for 3 devices
+    const UNPACKED_1: &[(u16, &[u8])] = &[
+        (0x0000, &[0x00, 0x00]),
+        (0x0001, &[0x00, 0x02]),
+        (0x0002, &[0x00, 0x04]),
+    ];
+    const PACKED_1: &[u8] = &[
+        0x00, 0x00, // Sub-Device: Root
+        0x02,       // len: 2 bytes
+        0x00, 0x00, // Data: 0
+        0x00, 0x01, // sub-device: 1
+        0x02,       // len: 2
+        0x00, 0x02, // data: 2
+        0x00, 0x02, // sub-device: 1
+        0x02,       // len: 2
+        0x00, 0x04, // data: 2
+    ];
+
+    // Test 2: GET_PERSONALITY_DESCRIPTION by index for 4 values
+    const UNPACKED_2: &[(u16, &[u8])] = &[
+        (0x0001, b"\x00\x10Standard"),
+        (0x0002, b"\x00\x0AReduced 8-bit"),
+        (0x0003, b"\x00\x18Direct Emitters"),
+        (0x0004, b"\x00\x08Macros Only"),
+    ];
+    const PACKED_2: &[u8] = &[
+        0x00, 0x01, // Personality: 1
+        10,
+        // b"\x00\x10Standard",
+        0x00, 0x10, 0x53, 0x74, 0x61, 0x6e, 0x64, 0x61, 0x72, 0x64,
+        0x00, 0x02,
+        15,
+        0x00, 0x0a, 0x52, 0x65, 0x64, 0x75, 0x63, 0x65, 0x64, 0x20, 0x38, 0x2d, 0x62, 0x69, 0x74,
+        // b"\x00\x0AReduced 8-bit",
+        0x00, 0x03,
+        17,
+        0x00, 0x18, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x20, 0x45, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x72, 0x73,
+        // b"\x00\x18Direct Emitters",
+        0x00, 0x04,
+        13,
+        0x00, 0x08, 0x4d, 0x61, 0x63, 0x72, 0x6f, 0x73, 0x20, 0x4f, 0x6e, 0x6c, 0x79,
+        // b"\x00\x08Macros Only",
+    ];
+
+    #[cfg(not(feature = "alloc"))]
+    type Vec<T> = heapless::Vec<T, 231>;
+
+    fn pack_all(unpacked_data: &[(u16, &[u8])]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (ident, data) in unpacked_data {
+            write_packed_entry(&mut out, *ident, data);
+        }
+        out
+    }
+    fn unpack_all<'a>(data: &'a[u8]) -> Result<Vec<(u16, &'a [u8])>, ()> {
+        let out: Result<Vec<_>, _> = PackedEntryIterator::new(data).collect();
+        out
+    }
+
+    #[test]
+    fn pack_data_dmx_start_address() {
+        let packed = pack_all(UNPACKED_1);
+        assert_eq!(packed, PACKED_1)
+    }
+    #[test]
+    fn unpack_data_dmx_start_address() {
+        let out = unpack_all(PACKED_1).unwrap();
+        assert_eq!(out, UNPACKED_1)
+    }
+
+    #[test]
+    fn pack_data_personality_description() {
+        let packed = pack_all(UNPACKED_2);
+        assert_eq!(packed, PACKED_2)
+    }
+    #[test]
+    fn unpack_data_personality_description() {
+        let out = unpack_all(PACKED_2).unwrap();
+        assert_eq!(out, UNPACKED_2)
+    }
 }


### PR DESCRIPTION
Adds most of the packet types and extra enum values.
Also fixes the GetSensorDefinition response serialiser as I noticed it was wrong while doing some work.

Still missing the packed messages:
- Could be a Vec<(ParameterId, Vec<u8>)
- or parse them fully to a request/response object (potentially difficult as we need a new Vec for each parameter we are serialising)

(Also I didn't use the vec extension as there were only a few packets so it didn't really seem worth it)
